### PR TITLE
Adjust vendor path helper for new hierarchy

### DIFF
--- a/nvim/lua/config/util.lua
+++ b/nvim/lua/config/util.lua
@@ -1,9 +1,23 @@
 local M = {}
 
+local uv = vim.uv or vim.loop
 local config_root = vim.fn.stdpath("config")
 
+local function dir_exists(path)
+  local stat = uv.fs_stat(path)
+  return stat and stat.type == "directory"
+end
+
+local vendor_root = config_root .. "/vendor/plugins"
+if not dir_exists(vendor_root) then
+  local repo_vendor = config_root .. "/../vendor/plugins"
+  if dir_exists(repo_vendor) then
+    vendor_root = repo_vendor
+  end
+end
+
 function M.vendor(name)
-  return vim.fs.normalize(config_root .. "/vendor/plugins/" .. name)
+  return vim.fs.normalize(vendor_root .. "/" .. name)
 end
 
 return M


### PR DESCRIPTION
## Summary
- allow the vendor path helper to detect the vendored plugin directory in the new repository layout
- keep compatibility with prior layout when the vendored plugins live directly under the config root

## Testing
- nvim --headless --clean -c "lua package.path = package.path .. ';' .. vim.fn.getcwd() .. '/nvim/lua/?.lua;' .. vim.fn.getcwd() .. '/nvim/lua/?/init.lua'" -c "lua local util = require('config.util'); print(util.vendor('lazy.nvim'))" -c 'qa!' *(fails: `nvim` command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cffe812a808331805ad472b09a1ccb