### PR TITLE
Enable mouse support in Neovim configuration

### DIFF
--- a/nvim/lua/config/options.lua
+++ b/nvim/lua/config/options.lua
@@ -18,3 +18,4 @@ opt.updatetime = 250
 opt.completeopt = { "menu", "menuone", "noselect" }
 opt.clipboard = "unnamedplus"
 opt.wrap = false
+opt.mouse = "a"


### PR DESCRIPTION
## Summary
- enable mouse support by setting the `mouse` option to "a"

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d0006417a88331bdb9312864d87c9a