### PR TITLE
Remove vendored devicons subtree

### DIFF
--- a/nvim/lua/plugins/nvim-web-devicons.lua
+++ b/nvim/lua/plugins/nvim-web-devicons.lua
@@ -1,0 +1,123 @@
+local util = require("config.util")
+
+return {
+  name = "nvim-web-devicons",
+  dir = util.vendor("nvim-web-devicons"),
+  config = function()
+    local ok, devicons = pcall(require, "nvim-web-devicons")
+    if not ok then
+      vim.notify("nvim-web-devicons failed to load", vim.log.levels.WARN)
+      return
+    end
+
+    devicons.setup({
+      color_icons = true,
+      default = true,
+      override_by_extension = {
+        lua = {
+          icon = "",
+          color = "#51a0cf",
+          name = "Lua",
+        },
+        py = {
+          icon = "",
+          color = "#ffbc03",
+          name = "Python",
+        },
+        rs = {
+          icon = "",
+          color = "#dea584",
+          name = "Rust",
+        },
+        go = {
+          icon = "",
+          color = "#00add8",
+          name = "Go",
+        },
+        ts = {
+          icon = "",
+          color = "#519aba",
+          name = "TypeScript",
+        },
+        js = {
+          icon = "",
+          color = "#f7df1e",
+          name = "JavaScript",
+        },
+        jsx = {
+          icon = "",
+          color = "#519aba",
+          name = "JavaScriptReact",
+        },
+        tsx = {
+          icon = "",
+          color = "#519aba",
+          name = "TypeScriptReact",
+        },
+        json = {
+          icon = "",
+          color = "#cbcb41",
+          name = "Json",
+        },
+        lock = {
+          icon = "",
+          color = "#c678dd",
+          name = "Lock",
+        },
+        md = {
+          icon = "",
+          color = "#519aba",
+          name = "Markdown",
+        },
+        sh = {
+          icon = "",
+          color = "#4d5a5e",
+          name = "Shell",
+        },
+        toml = {
+          icon = "",
+          color = "#6d8086",
+          name = "Toml",
+        },
+        yml = {
+          icon = "",
+          color = "#6d8086",
+          name = "Yaml",
+        },
+        yaml = {
+          icon = "",
+          color = "#6d8086",
+          name = "Yaml",
+        },
+      },
+      override_by_filename = {
+        ["Dockerfile"] = {
+          icon = "",
+          color = "#0db7ed",
+          name = "Dockerfile",
+        },
+        [".gitignore"] = {
+          icon = "",
+          color = "#f14c28",
+          name = "GitIgnore",
+        },
+        ["Makefile"] = {
+          icon = "",
+          color = "#6d8086",
+          name = "Makefile",
+        },
+        ["LICENSE"] = {
+          icon = "",
+          color = "#cfcfcf",
+          name = "License",
+        },
+        ["README.md"] = {
+          icon = "",
+          color = "#519aba",
+          name = "Readme",
+        },
+      },
+    })
+  end,
+}
+

--- a/nvim/lua/plugins/telescope.lua
+++ b/nvim/lua/plugins/telescope.lua
@@ -7,6 +7,7 @@ return {
   dependencies = {
     "plenary.nvim",
     "telescope-fzf-native.nvim",
+    "nvim-web-devicons",
   },
   config = function()
     local telescope = require("telescope")

--- a/scripts/plugins-list.txt
+++ b/scripts/plugins-list.txt
@@ -9,6 +9,7 @@ https://github.com/hrsh7th/cmp-nvim-lsp    cmp-nvim-lsp               main
 https://github.com/L3MON4D3/LuaSnip        LuaSnip                    master
 https://github.com/saadparwaiz1/cmp_luasnip cmp_luasnip               master
 https://github.com/nvim-treesitter/nvim-treesitter nvim-treesitter    master
+https://github.com/nvim-tree/nvim-web-devicons nvim-web-devicons      master
 https://github.com/lewis6991/gitsigns.nvim gitsigns.nvim              main
 https://github.com/akinsho/toggleterm.nvim toggleterm.nvim            main
 https://github.com/navarasu/onedark.nvim   onedark.nvim               master


### PR DESCRIPTION
## Summary
- remove the previously committed `nvim-web-devicons` subtree from `vendor/plugins`

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d01bb6fd988331baf70372fcafa33a