### PR TITLE
feat: add lazy-loaded nvim-tree file explorer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # nvim-pro-kit
 nvim-pro-kit is a batteries-included Neovim configuration tailored for professional development workflows. Every dependency is vendored so you can install it completely offline while keeping your editor setup reproducible and version-controlled.
 
+`nvim-pro-kit` 是为专业开发流程量身打造的全能型 Neovim 配置。所有依赖都已预先内建，即使在离线环境也能快速部署，同时确保编辑器配置可重现且易于版本控制。
+
 ## 🚀 Installation
 
 Use the Python bootstrap installer to set up the configuration without touching

--- a/nvim/lua/config/keymaps.lua
+++ b/nvim/lua/config/keymaps.lua
@@ -6,8 +6,6 @@ map({ "n", "v" }, "<Space>", "<Nop>", default_opts)
 map("n", "<leader>w", "<cmd>w<cr>", vim.tbl_extend("force", default_opts, { desc = "Save file" }))
 map("n", "<leader>q", "<cmd>qa<cr>", vim.tbl_extend("force", default_opts, { desc = "Quit Neovim" }))
 map("n", "<leader>h", "<cmd>nohlsearch<cr>", vim.tbl_extend("force", default_opts, { desc = "Clear search highlight" }))
-map("n", "<leader>e", "<cmd>Lex 30<cr>", vim.tbl_extend("force", default_opts, { desc = "Open file explorer" }))
-
 map("n", "<leader>bd", "<cmd>bdelete<cr>", vim.tbl_extend("force", default_opts, { desc = "Delete buffer" }))
 map("n", "<leader>bn", "<cmd>bnext<cr>", vim.tbl_extend("force", default_opts, { desc = "Next buffer" }))
 map("n", "<leader>bp", "<cmd>bprevious<cr>", vim.tbl_extend("force", default_opts, { desc = "Previous buffer" }))

--- a/nvim/lua/plugins/nvim-tree.lua
+++ b/nvim/lua/plugins/nvim-tree.lua
@@ -1,0 +1,39 @@
+return {
+  "nvim-tree/nvim-tree.lua",
+  dependencies = {
+    "nvim-tree/nvim-web-devicons",
+  },
+  cmd = {
+    "NvimTreeToggle",
+    "NvimTreeFocus",
+    "NvimTreeFindFile",
+  },
+  keys = {
+    {
+      "<leader>e",
+      function()
+        require("nvim-tree.api").tree.toggle({ focus = false })
+      end,
+      desc = "Toggle file explorer",
+    },
+  },
+  init = function()
+    vim.g.loaded_netrw = 1
+    vim.g.loaded_netrwPlugin = 1
+  end,
+  config = function()
+    require("nvim-tree").setup({
+      disable_netrw = false,
+      hijack_netrw = false,
+      sync_root_with_cwd = true,
+      respect_buf_cwd = true,
+      update_focused_file = {
+        enable = true,
+        update_root = true,
+      },
+      view = {
+        width = 35,
+      },
+    })
+  end,
+}


### PR DESCRIPTION
## Summary
- add a lazy-loaded nvim-tree configuration with a <leader>e toggle
- remove the legacy netrw keybinding so the tree mapping is provided by the plugin
- document the project with a brief Chinese introduction for native readers

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d022929a10833194dcd8bba9857456