### PR TITLE
Convert Tree-sitter sync script to Python

### DIFF
--- a/nvim/lua/config/treesitter_manifest.lua
+++ b/nvim/lua/config/treesitter_manifest.lua
@@ -1,0 +1,66 @@
+local util = require("config.util")
+
+local M = {}
+
+local function warn(message)
+  if vim.notify then
+    vim.schedule(function()
+      vim.notify(message, vim.log.levels.WARN, { title = "Tree-sitter" })
+    end)
+  end
+end
+
+local trim = vim.trim or function(str)
+  return (str:gsub("^%s+", ""):gsub("%s+$", ""))
+end
+
+local function manifest_path()
+  local root = util.repo_root()
+  if not root then
+    return nil
+  end
+  return vim.fs.normalize(root .. "/scripts/treesitter-parsers.txt")
+end
+
+local function parse_lines(lines)
+  local languages = {}
+  for _, line in ipairs(lines) do
+    local trimmed = line:gsub("#.*", "")
+    trimmed = trim(trimmed)
+    if trimmed ~= "" then
+      table.insert(languages, trimmed)
+    end
+  end
+  return languages
+end
+
+function M.path()
+  return manifest_path()
+end
+
+function M.languages(opts)
+  opts = opts or {}
+  local path = manifest_path()
+  if not path or vim.fn.filereadable(path) == 0 then
+    if not opts.silent then
+      warn(string.format("Tree-sitter manifest not found at %s", path or "<unknown>"))
+    end
+    return {}
+  end
+
+  local ok, lines = pcall(vim.fn.readfile, path)
+  if not ok then
+    if not opts.silent then
+      warn(string.format("Failed to read Tree-sitter manifest at %s: %s", path, lines))
+    end
+    return {}
+  end
+
+  local languages = parse_lines(lines)
+  if #languages == 0 and not opts.silent then
+    warn(string.format("Tree-sitter manifest at %s does not list any parsers", path))
+  end
+  return languages
+end
+
+return M

--- a/nvim/lua/config/util.lua
+++ b/nvim/lua/config/util.lua
@@ -8,9 +8,28 @@ local function dir_exists(path)
   return stat and stat.type == "directory"
 end
 
+local function find_repo_root()
+  local dir = vim.fs.normalize(config_root)
+  while dir do
+    local git_dir = dir .. "/.git"
+    local stat = uv.fs_stat(git_dir)
+    if stat then
+      return dir
+    end
+    local parent = vim.fs.dirname(dir)
+    if not parent or parent == dir then
+      break
+    end
+    dir = parent
+  end
+  return vim.fs.normalize(config_root)
+end
+
+local repo_root = find_repo_root()
+
 local vendor_root = config_root .. "/vendor/plugins"
 if not dir_exists(vendor_root) then
-  local repo_vendor = config_root .. "/../vendor/plugins"
+  local repo_vendor = repo_root .. "/vendor/plugins"
   if dir_exists(repo_vendor) then
     vendor_root = repo_vendor
   end
@@ -18,6 +37,10 @@ end
 
 function M.vendor(name)
   return vim.fs.normalize(vendor_root .. "/" .. name)
+end
+
+function M.repo_root()
+  return repo_root
 end
 
 return M

--- a/nvim/lua/plugins/nvim-treesitter.lua
+++ b/nvim/lua/plugins/nvim-treesitter.lua
@@ -1,21 +1,17 @@
 local util = require("config.util")
+local manifest = require("config.treesitter_manifest")
 
 return {
   name = "nvim-treesitter",
   dir = util.vendor("nvim-treesitter"),
   event = { "BufReadPost", "BufNewFile" },
   config = function()
+    local ensure_installed = manifest.languages()
+
     require("nvim-treesitter.configs").setup({
-      ensure_installed = {
-        "bash",
-        "lua",
-        "vim",
-        "vimdoc",
-        "json",
-        "python",
-        "javascript",
-        "typescript",
-      },
+      -- Update scripts/treesitter-parsers.txt and run scripts/treesitter-sync.py
+      -- to modify this list.
+      ensure_installed = ensure_installed,
       auto_install = false,
       highlight = {
         enable = true,

--- a/scripts/treesitter-parsers.txt
+++ b/scripts/treesitter-parsers.txt
@@ -1,0 +1,40 @@
+# List of Tree-sitter grammars managed by nvim-pro-kit.
+# Keep this file alphabetized. It is consumed by scripts/treesitter-sync.py
+# and by the Neovim configuration (see nvim/lua/plugins/nvim-treesitter.lua).
+
+asm
+bash
+c
+cmake
+comment
+cpp
+css
+diff
+dockerfile
+fish
+git_rebase
+gitattributes
+gitcommit
+gitignore
+go
+gomod
+html
+javascript
+json
+jsonc
+lua
+make
+markdown
+markdown_inline
+python
+query
+regex
+rust
+sql
+sxhkd
+toml
+tsx
+typescript
+vim
+vimdoc
+yaml

--- a/scripts/treesitter-sync.py
+++ b/scripts/treesitter-sync.py
@@ -1,0 +1,278 @@
+#!/usr/bin/env python3
+"""Install, update, and prune Tree-sitter parsers listed in the manifest."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import Iterable, MutableMapping, Sequence
+
+
+def parse_args(argv: Sequence[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Install, update, and prune Tree-sitter parsers",
+    )
+    parser.add_argument(
+        "--manifest",
+        help="Override the parser manifest path.",
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Verify installed parsers match the manifest without modifying disk.",
+    )
+    prune_group = parser.add_mutually_exclusive_group()
+    prune_group.add_argument(
+        "--prune",
+        dest="prune",
+        action="store_true",
+        help="Remove parsers that are not listed in the manifest (default).",
+    )
+    prune_group.add_argument(
+        "--no-prune",
+        dest="prune",
+        action="store_false",
+        help="Skip pruning of extraneous parsers.",
+    )
+    parser.set_defaults(prune=True)
+    return parser.parse_args(argv)
+
+
+def repo_root() -> Path:
+    try:
+        output = subprocess.check_output(
+            ["git", "rev-parse", "--show-toplevel"],
+            text=True,
+        )
+    except subprocess.CalledProcessError as exc:
+        raise SystemExit("error: failed to determine git repository root") from exc
+    return Path(output.strip())
+
+
+def load_manifest(path: Path) -> list[str]:
+    try:
+        raw_lines = path.read_text(encoding="utf-8").splitlines()
+    except OSError as exc:
+        raise SystemExit(f"error: failed to read manifest at {path}: {exc}") from exc
+
+    languages: list[str] = []
+    for line in raw_lines:
+        stripped = line.split("#", 1)[0].strip()
+        if stripped:
+            languages.append(stripped)
+    return languages
+
+
+def build_nvim_command(nvim_bin: str) -> list[str]:
+    runtime_setup = (
+        "+lua do local root = vim.env.TREESITTER_SYNC_ROOT or '' "
+        "if root ~= '' then "
+        "local paths = {'/vendor/plugins/plenary.nvim','/vendor/plugins/nvim-treesitter','/nvim'} "
+        "for _, suffix in ipairs(paths) do "
+        "vim.opt.runtimepath:prepend(root .. suffix) "
+        "end "
+        "end "
+        "end"
+    )
+    return [
+        nvim_bin,
+        "--headless",
+        "--clean",
+        runtime_setup,
+        "+runtime plugin/plenary.vim",
+        "+runtime plugin/nvim-treesitter.lua",
+    ]
+
+
+def run_nvim(
+    base_cmd: Sequence[str],
+    env: MutableMapping[str, str],
+    extra_args: Iterable[str],
+    *,
+    capture_output: bool = False,
+) -> str:
+    stdout = subprocess.PIPE if capture_output else None
+    stderr = subprocess.STDOUT if capture_output else None
+    try:
+        result = subprocess.run(
+            [*base_cmd, *extra_args],
+            env=env,
+            check=True,
+            text=True,
+            stdout=stdout,
+            stderr=stderr,
+        )
+    except subprocess.CalledProcessError as exc:
+        if capture_output and exc.stdout:
+            sys.stderr.write(exc.stdout)
+        raise SystemExit("error: Neovim command failed") from exc
+    return result.stdout or ""
+
+
+def install_or_update(base_cmd: Sequence[str], env: MutableMapping[str, str], check: bool) -> None:
+    if check:
+        return
+
+    lua_cmd = (
+        "+lua local manifest=require('config.treesitter_manifest');"
+        "local langs=manifest.languages({ silent = true });"
+        "if #langs==0 then error('Tree-sitter manifest is empty') end;"
+        "local install=require('nvim-treesitter.install');"
+        "local update=install.update({ with_sync = true });"
+        "local unpack=table.unpack or unpack;"
+        "update(unpack(langs))"
+    )
+
+    run_nvim(base_cmd, env, [lua_cmd, "+qa"])
+
+
+def collect_dirs(base_cmd: Sequence[str], env: MutableMapping[str, str]) -> tuple[str, str]:
+    lua_cmd = (
+        "+lua local configs=require('nvim-treesitter.configs');"
+        "local function first(...) local t={...};return t[1];end;"
+        "local parser_dir=first(configs.get_parser_install_dir());"
+        "local info_dir=first(configs.get_parser_info_dir());"
+        "io.write((parser_dir or '') .. '\n' .. (info_dir or ''))"
+    )
+    output = run_nvim(base_cmd, env, [lua_cmd, "+qa"], capture_output=True)
+    lines = output.splitlines()
+    parser_dir = lines[0].strip() if lines else ""
+    info_dir = lines[1].strip() if len(lines) > 1 else ""
+    return parser_dir, info_dir
+
+
+def list_parsers(parser_dir: str) -> set[str]:
+    if not parser_dir:
+        return set()
+    directory = Path(parser_dir)
+    if not directory.is_dir():
+        return set()
+
+    names: set[str] = set()
+    for pattern in ("*.so", "*.dll", "*.dylib", "*.wasm"):
+        for path in directory.glob(pattern):
+            names.add(path.stem.split(".")[0])
+    return names
+
+
+def list_revisions(info_dir: str) -> set[str]:
+    if not info_dir:
+        return set()
+    directory = Path(info_dir)
+    if not directory.is_dir():
+        return set()
+
+    return {path.stem for path in directory.glob("*.revision")}
+
+
+def prune_extras(
+    extra: Iterable[str],
+    parser_dir: str,
+    info_dir: str,
+) -> None:
+    parser_path = Path(parser_dir) if parser_dir else None
+    info_path = Path(info_dir) if info_dir else None
+
+    extras = sorted(set(extra))
+    if not extras:
+        return
+
+    print(f"Pruning extraneous Tree-sitter parsers: {' '.join(extras)}")
+    for lang in extras:
+        if parser_path:
+            for suffix in (".so", ".dll", ".dylib", ".wasm"):
+                try:
+                    (parser_path / f"{lang}{suffix}").unlink(missing_ok=True)
+                except OSError:
+                    pass
+        if info_path:
+            try:
+                (info_path / f"{lang}.revision").unlink(missing_ok=True)
+            except OSError:
+                pass
+
+
+def report(
+    manifest_langs: Sequence[str],
+    installed: Set[str],
+    revisions: Set[str],
+    *,
+    check: bool,
+    prune: bool,
+    parser_dir: str,
+    info_dir: str,
+) -> None:
+    manifest_set = set(manifest_langs)
+    missing = [lang for lang in manifest_langs if lang not in installed]
+    extra = (installed | revisions) - manifest_set
+
+    if check:
+        status = 0
+        if missing:
+            sys.stderr.write(
+                "Missing Tree-sitter parsers: " + " ".join(missing) + "\n"
+            )
+            status = 1
+        if extra:
+            sys.stderr.write(
+                "Extraneous Tree-sitter parsers: " + " ".join(sorted(extra)) + "\n"
+            )
+            status = 1
+        if status != 0:
+            raise SystemExit(status)
+        return
+
+    if prune and extra:
+        prune_extras(extra, parser_dir, info_dir)
+    elif extra:
+        print(
+            "Extraneous Tree-sitter parsers detected (use --prune to remove): "
+            + " ".join(sorted(extra))
+        )
+
+    if missing:
+        sys.stderr.write(
+            "Parsers still missing after update: " + " ".join(missing) + "\n"
+        )
+        raise SystemExit(1)
+
+
+def main(argv: Sequence[str]) -> None:
+    args = parse_args(argv)
+
+    root = repo_root()
+    manifest_path = Path(args.manifest) if args.manifest else root / "scripts" / "treesitter-parsers.txt"
+    if not manifest_path.is_file():
+        raise SystemExit(f"error: manifest not found at {manifest_path}")
+
+    manifest_langs = load_manifest(manifest_path)
+    if not manifest_langs:
+        raise SystemExit(
+            f"error: manifest {manifest_path} does not list any Tree-sitter parsers"
+        )
+
+    nvim_bin = os.environ.get("NVIM_BIN", "nvim")
+    base_cmd = build_nvim_command(nvim_bin)
+    env = os.environ.copy()
+    env["TREESITTER_SYNC_ROOT"] = str(root)
+
+    install_or_update(base_cmd, env, args.check)
+    parser_dir, info_dir = collect_dirs(base_cmd, env)
+    installed = list_parsers(parser_dir)
+    revisions = list_revisions(info_dir)
+    report(
+        manifest_langs,
+        installed,
+        revisions,
+        check=args.check,
+        prune=args.prune,
+        parser_dir=parser_dir,
+        info_dir=info_dir,
+    )
+
+
+if __name__ == "__main__":
+    main(sys.argv[1:])


### PR DESCRIPTION
## Summary
- add `scripts/treesitter-parsers.txt` as the canonical Tree-sitter grammar list used by tooling and config
- replace the shell-based Tree-sitter sync script with a Python implementation that installs, updates, checks, and prunes parsers
- load the manifest in the Neovim Tree-sitter configuration and expose a repo root helper for manifest access

## Testing
- scripts/treesitter-sync.py --help

------
https://chatgpt.com/codex/tasks/task_e_68d0a87786a083319e2d66750e425ad9