### PR TITLE
Fix Tree-sitter manifest discovery for sync script

### DIFF
--- a/nvim/lua/config/util.lua
+++ b/nvim/lua/config/util.lua
@@ -9,6 +9,14 @@ local function dir_exists(path)
 end
 
 local function find_repo_root()
+  local env_root = vim.env.NVIM_PRO_KIT_ROOT or vim.env.TREESITTER_SYNC_ROOT
+  if env_root and env_root ~= "" then
+    local normalized = vim.fs.normalize(env_root)
+    if dir_exists(normalized) then
+      return normalized
+    end
+  end
+
   local dir = vim.fs.normalize(config_root)
   while dir do
     local git_dir = dir .. "/.git"


### PR DESCRIPTION
## Summary
- respect NVIM_PRO_KIT_ROOT and TREESITTER_SYNC_ROOT when locating the repository root from Lua config

## Testing
- ❌ `./scripts/treesitter-sync.py` *(missing `nvim` binary in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d0b37d748083318ff62b20d5e322e2