### PR TITLE
Refine Tree-sitter vendor workflow

### DIFF
--- a/scripts/treesitter-sync.py
+++ b/scripts/treesitter-sync.py
@@ -116,9 +116,10 @@ def install_or_update(base_cmd: Sequence[str], env: MutableMapping[str, str], ch
         "local vendor=require('config.treesitter_vendor');"
         "vendor.apply(langs);"
         "local install=require('nvim-treesitter.install');"
-        "local update=install.update({ with_sync = true });"
-        "local unpack=table.unpack or unpack;"
-        "update(unpack(langs))"
+        "local runner=install.commands.TSInstallSync['run!'];"
+        "for _,lang in ipairs(langs) do"
+        " runner(lang);"
+        "end"
     )
 
     run_nvim(base_cmd, env, [lua_cmd, "+qa"])


### PR DESCRIPTION
## Summary
- snapshot full parser repositories when vendoring Tree-sitter grammars and prune removed languages
- validate vendored layouts and runtime headers before writing metadata
- trigger per-language TSInstallSync runs so parsers build directly from vendored sources

## Testing
- `python3 scripts/treesitter-vendor.py --check` *(fails: Neovim not available in container)*
- `python3 scripts/treesitter-sync.py --check` *(fails: Neovim not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d178d7585c833190e91083bc3c5ebc