### PR TITLE
Refactor Tree-sitter vendor and sync workflows

### DIFF
--- a/scripts/treesitter-sync.py
+++ b/scripts/treesitter-sync.py
@@ -1,19 +1,26 @@
 #!/usr/bin/env python3
-"""Install, update, and prune Tree-sitter parsers listed in the manifest."""
+"""Build Tree-sitter parsers from vendored sources and install them."""
 
 from __future__ import annotations
 
 import argparse
+import json
 import os
+import shlex
+import shutil
 import subprocess
 import sys
 from pathlib import Path
-from typing import Iterable, MutableMapping, Sequence
+from typing import Sequence
+
+
+class BuildError(RuntimeError):
+    """Raised when a parser fails to build."""
 
 
 def parse_args(argv: Sequence[str]) -> argparse.Namespace:
     parser = argparse.ArgumentParser(
-        description="Install, update, and prune Tree-sitter parsers",
+        description="Build Tree-sitter parsers from vendored sources",
     )
     parser.add_argument(
         "--manifest",
@@ -22,7 +29,7 @@ def parse_args(argv: Sequence[str]) -> argparse.Namespace:
     parser.add_argument(
         "--check",
         action="store_true",
-        help="Verify installed parsers match the manifest without modifying disk.",
+        help="Verify installed parsers without building them.",
     )
     prune_group = parser.add_mutually_exclusive_group()
     prune_group.add_argument(
@@ -66,173 +73,255 @@ def load_manifest(path: Path) -> list[str]:
     return languages
 
 
-def build_nvim_command(nvim_bin: str) -> list[str]:
-    runtime_setup = (
-        "+lua (function(root) if root ~= '' then local paths = {'/vendor/plugins/plenary.nvim','/vendor/plugins/nvim-treesitter','/nvim'} for _, suffix in ipairs(paths) do vim.opt.runtimepath:prepend(root .. suffix) end end end)(vim.env.TREESITTER_SYNC_ROOT or '')"
-    )
-    return [
-        nvim_bin,
-        "--headless",
-        "--clean",
-        runtime_setup,
-        "+runtime plugin/plenary.vim",
-        "+runtime plugin/nvim-treesitter.lua",
-    ]
+def load_metadata(path: Path) -> tuple[dict[str, dict[str, object]], Path]:
+    if not path.is_file():
+        raise SystemExit(
+            f"error: Tree-sitter metadata not found at {path}. "
+            "Run scripts/treesitter-vendor.py first."
+        )
 
-
-def run_nvim(
-    base_cmd: Sequence[str],
-    env: MutableMapping[str, str],
-    extra_args: Iterable[str],
-    *,
-    capture_output: bool = False,
-) -> str:
-    stdout = subprocess.PIPE if capture_output else None
-    stderr = subprocess.STDOUT if capture_output else None
     try:
-        result = subprocess.run(
-            [*base_cmd, *extra_args],
-            env=env,
-            check=True,
-            text=True,
-            stdout=stdout,
-            stderr=stderr,
-        )
-    except subprocess.CalledProcessError as exc:
-        if capture_output and exc.stdout:
-            sys.stderr.write(exc.stdout)
-        raise SystemExit("error: Neovim command failed") from exc
-    return result.stdout or ""
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise SystemExit(f"error: failed to load metadata from {path}: {exc}") from exc
+
+    if not isinstance(raw, dict):
+        raise SystemExit("error: metadata has unexpected structure")
+
+    metadata: dict[str, dict[str, object]] = {}
+    for lang, info in raw.items():
+        if isinstance(info, dict):
+            metadata[lang] = info
+
+    return metadata, path.parent
 
 
-def install_or_update(base_cmd: Sequence[str], env: MutableMapping[str, str], check: bool) -> None:
-    if check:
-        return
-
-    lua_cmd = (
-        "+lua local manifest=require('config.treesitter_manifest');"
-        "local langs=manifest.languages({ silent = true });"
-        "if #langs==0 then error('Tree-sitter manifest is empty') end;"
-        "local vendor=require('config.treesitter_vendor');"
-        "vendor.apply(langs);"
-        "local install=require('nvim-treesitter.install');"
-        "local runner=install.commands.TSInstallSync['run!'];"
-        "for _,lang in ipairs(langs) do"
-        " runner(lang);"
-        "end"
-    )
-
-    run_nvim(base_cmd, env, [lua_cmd, "+qa"])
+def library_suffix() -> str:
+    if sys.platform == "darwin":
+        return ".dylib"
+    if os.name == "nt":
+        return ".dll"
+    return ".so"
 
 
-def collect_dirs(base_cmd: Sequence[str], env: MutableMapping[str, str]) -> tuple[str, str]:
-    lua_cmd = (
-        "+lua local configs=require('nvim-treesitter.configs');"
-        "local function first(...) local t={...};return t[1];end;"
-        "local parser_dir=first(configs.get_parser_install_dir());"
-        "local info_dir=first(configs.get_parser_info_dir());"
-        "io.write((parser_dir or '') .. '\n' .. (info_dir or ''))"
-    )
-    output = run_nvim(base_cmd, env, [lua_cmd, "+qa"], capture_output=True)
-    lines = output.splitlines()
-    parser_dir = lines[0].strip() if lines else ""
-    info_dir = lines[1].strip() if len(lines) > 1 else ""
-    return parser_dir, info_dir
+def format_command(args: Sequence[str]) -> str:
+    return " ".join(shlex.quote(arg) for arg in args)
 
 
-def list_parsers(parser_dir: str) -> set[str]:
-    if not parser_dir:
-        return set()
-    directory = Path(parser_dir)
-    if not directory.is_dir():
-        return set()
-
-    names: set[str] = set()
-    for pattern in ("*.so", "*.dll", "*.dylib", "*.wasm"):
-        for path in directory.glob(pattern):
-            names.add(path.stem.split(".")[0])
-    return names
+def log(message: str) -> None:
+    print(message)
 
 
-def list_revisions(info_dir: str) -> set[str]:
-    if not info_dir:
-        return set()
-    directory = Path(info_dir)
-    if not directory.is_dir():
-        return set()
-
-    return {path.stem for path in directory.glob("*.revision")}
+def log_step(lang: str, message: str) -> None:
+    print(f"[{lang}] {message}")
 
 
-def prune_extras(
-    extra: Iterable[str],
-    parser_dir: str,
-    info_dir: str,
+def has_cpp_sources(files: Sequence[str]) -> bool:
+    return any(Path(file).suffix in {".cc", ".cpp", ".cxx"} for file in files)
+
+
+def run_command(
+    args: Sequence[str], *, cwd: Path | None, check: bool = True, env: dict[str, str] | None = None
 ) -> None:
-    parser_path = Path(parser_dir) if parser_dir else None
-    info_path = Path(info_dir) if info_dir else None
-
-    extras = sorted(set(extra))
-    if not extras:
-        return
-
-    print(f"Pruning extraneous Tree-sitter parsers: {' '.join(extras)}")
-    for lang in extras:
-        if parser_path:
-            for suffix in (".so", ".dll", ".dylib", ".wasm"):
-                try:
-                    (parser_path / f"{lang}{suffix}").unlink(missing_ok=True)
-                except OSError:
-                    pass
-        if info_path:
-            try:
-                (info_path / f"{lang}.revision").unlink(missing_ok=True)
-            except OSError:
-                pass
+    location = f" (cwd={cwd})" if cwd else ""
+    log(f"$ {format_command(args)}{location}")
+    subprocess.run(args, cwd=cwd, check=check, env=env)
 
 
-def report(
-    manifest_langs: Sequence[str],
-    installed: Set[str],
-    revisions: Set[str],
+def compile_with_compiler(
+    lang: str,
+    files: Sequence[str],
+    base_dir: Path,
+    output_path: Path,
     *,
-    check: bool,
-    prune: bool,
-    parser_dir: str,
-    info_dir: str,
-) -> None:
-    manifest_set = set(manifest_langs)
-    missing = [lang for lang in manifest_langs if lang not in installed]
-    extra = (installed | revisions) - manifest_set
+    cxx_standard: str | None,
+) -> Path:
+    compiler = os.environ.get("CC", "cc")
+    args: list[str] = [compiler, "-o", str(output_path), "-I", str(base_dir / "src")]
+    args.extend(str(Path(file)) for file in files)
+    args.append("-Os")
 
-    if check:
-        status = 0
-        if missing:
-            sys.stderr.write(
-                "Missing Tree-sitter parsers: " + " ".join(missing) + "\n"
-            )
-            status = 1
-        if extra:
-            sys.stderr.write(
-                "Extraneous Tree-sitter parsers: " + " ".join(sorted(extra)) + "\n"
-            )
-            status = 1
-        if status != 0:
-            raise SystemExit(status)
+    if has_cpp_sources(files):
+        args.append(f"-std={cxx_standard}" if cxx_standard else "-std=c++14")
+        args.append("-lstdc++")
+    else:
+        args.append("-std=c11")
+
+    if sys.platform == "darwin":
+        args.append("-bundle")
+    else:
+        args.append("-shared")
+
+    if os.name != "nt":
+        args.append("-fPIC")
+
+    run_command(args, cwd=base_dir)
+    return output_path
+
+
+def compile_with_make(lang: str, base_dir: Path, output_name: str) -> tuple[Path, str]:
+    make_path = shutil.which("gmake") or shutil.which("make")
+    if not make_path:
+        raise BuildError(f"required build tool 'make' not found for parser {lang}")
+
+    env = os.environ.copy()
+    env.setdefault("TS", os.environ.get("TS", "true"))
+
+    run_command([make_path], cwd=base_dir, env=env)
+    artifact = base_dir / output_name
+    if not artifact.exists():
+        raise BuildError(
+            f"make completed for {lang} but expected artifact {output_name} was not produced"
+        )
+    return artifact, make_path
+
+
+def run_make_clean(make_path: str, base_dir: Path) -> None:
+    try:
+        env = os.environ.copy()
+        env.setdefault("TS", os.environ.get("TS", "true"))
+        run_command([make_path, "clean"], cwd=base_dir, check=False, env=env)
+    except OSError:
+        pass
+
+
+def build_parser(
+    lang: str,
+    info: dict[str, object],
+    vendor_root: Path,
+    parser_dir: Path,
+    *,
+    suffix: str,
+) -> Path:
+    source_dir = vendor_root / lang
+    if not source_dir.is_dir():
+        raise BuildError(f"vendored sources for {lang} not found at {source_dir}")
+
+    location = info.get("location")
+    location_path = Path(str(location)) if isinstance(location, str) and location else None
+    base_dir = source_dir / location_path if location_path else source_dir
+    if not base_dir.is_dir():
+        raise BuildError(f"expected directory for {lang} at {base_dir} is missing")
+
+    files = info.get("files")
+    if not isinstance(files, Sequence) or not all(isinstance(f, str) for f in files):
+        raise BuildError(f"metadata for {lang} does not list source files")
+    file_list = [str(f) for f in files]
+
+    output_name = f"parser{suffix}"
+    artifact_path = base_dir / output_name
+    if artifact_path.exists():
+        artifact_path.unlink()
+
+    use_makefile = bool(info.get("use_makefile")) or (base_dir / "Makefile").is_file()
+    make_path: str | None = None
+
+    log_step(lang, f"Building parser from {base_dir}")
+    if use_makefile:
+        artifact_path, make_path = compile_with_make(lang, base_dir, output_name)
+    else:
+        artifact_path = compile_with_compiler(
+            lang,
+            file_list,
+            base_dir,
+            artifact_path,
+            cxx_standard=str(info.get("cxx_standard")) if info.get("cxx_standard") else None,
+        )
+
+    if not artifact_path.exists():
+        raise BuildError(f"expected build artifact for {lang} not found at {artifact_path}")
+
+    parser_dir.mkdir(parents=True, exist_ok=True)
+    destination = parser_dir / f"{lang}{suffix}"
+    if destination.exists():
+        destination.unlink()
+
+    log_step(lang, f"Installing parser to {destination}")
+    shutil.move(str(artifact_path), destination)
+
+    if use_makefile and make_path:
+        run_make_clean(make_path, base_dir)
+
+    return destination
+
+
+def write_revision(info_dir: Path, lang: str, revision: object) -> None:
+    if not isinstance(revision, str) or not revision:
+        revision_path = info_dir / f"{lang}.revision"
+        if revision_path.exists():
+            revision_path.unlink()
         return
 
-    if prune and extra:
-        prune_extras(extra, parser_dir, info_dir)
-    elif extra:
-        print(
-            "Extraneous Tree-sitter parsers detected (use --prune to remove): "
-            + " ".join(sorted(extra))
-        )
+    info_dir.mkdir(parents=True, exist_ok=True)
+    revision_path = info_dir / f"{lang}.revision"
+    revision_path.write_text(revision + "\n", encoding="utf-8")
+    log_step(lang, f"Recorded revision {revision}")
 
-    if missing:
-        sys.stderr.write(
-            "Parsers still missing after update: " + " ".join(missing) + "\n"
-        )
+
+def collect_installed(parser_dir: Path, suffix: str) -> set[str]:
+    if not parser_dir.is_dir():
+        return set()
+    return {path.stem for path in parser_dir.glob(f"*{suffix}")}
+
+
+def collect_revisions(info_dir: Path) -> set[str]:
+    if not info_dir.is_dir():
+        return set()
+    return {path.stem for path in info_dir.glob("*.revision")}
+
+
+def prune_extra(parser_dir: Path, info_dir: Path, suffix: str, manifest_langs: set[str]) -> None:
+    installed = collect_installed(parser_dir, suffix)
+    revisions = collect_revisions(info_dir)
+    extras = sorted((installed | revisions) - manifest_langs)
+    for lang in extras:
+        lib_path = parser_dir / f"{lang}{suffix}"
+        rev_path = info_dir / f"{lang}.revision"
+        if lib_path.exists():
+            log(f"Removing extraneous parser {lib_path}")
+            lib_path.unlink()
+        if rev_path.exists():
+            log(f"Removing extraneous revision {rev_path}")
+            rev_path.unlink()
+
+
+def verify_installation(
+    manifest_langs: Sequence[str],
+    metadata: dict[str, dict[str, object]],
+    parser_dir: Path,
+    info_dir: Path,
+    *,
+    suffix: str,
+) -> None:
+    missing: list[str] = []
+    revision_issues: list[str] = []
+
+    for lang in manifest_langs:
+        lib_path = parser_dir / f"{lang}{suffix}"
+        if not lib_path.is_file():
+            missing.append(lang)
+            continue
+
+        info = metadata.get(lang)
+        if not info:
+            continue
+        revision = info.get("revision")
+        if isinstance(revision, str) and revision:
+            rev_path = info_dir / f"{lang}.revision"
+            try:
+                recorded = rev_path.read_text(encoding="utf-8").strip()
+            except OSError:
+                recorded = ""
+            if recorded != revision:
+                revision_issues.append(lang)
+
+    if missing or revision_issues:
+        if missing:
+            sys.stderr.write("Missing Tree-sitter parsers: " + " ".join(missing) + "\n")
+        if revision_issues:
+            sys.stderr.write(
+                "Revision metadata mismatch: " + " ".join(revision_issues) + "\n"
+            )
         raise SystemExit(1)
 
 
@@ -240,34 +329,51 @@ def main(argv: Sequence[str]) -> None:
     args = parse_args(argv)
 
     root = repo_root()
-    manifest_path = Path(args.manifest) if args.manifest else root / "scripts" / "treesitter-parsers.txt"
+    manifest_path = (
+        Path(args.manifest)
+        if args.manifest
+        else root / "scripts" / "treesitter-parsers.txt"
+    )
     if not manifest_path.is_file():
         raise SystemExit(f"error: manifest not found at {manifest_path}")
 
+    log(f"Using manifest {manifest_path}")
     manifest_langs = load_manifest(manifest_path)
     if not manifest_langs:
         raise SystemExit(
             f"error: manifest {manifest_path} does not list any Tree-sitter parsers"
         )
+    log(f"Manifest lists {len(manifest_langs)} parsers")
 
-    nvim_bin = os.environ.get("NVIM_BIN", "nvim")
-    base_cmd = build_nvim_command(nvim_bin)
-    env = os.environ.copy()
-    env["TREESITTER_SYNC_ROOT"] = str(root)
+    metadata_path = root / "vendor" / "tree-sitter" / "metadata.json"
+    metadata, vendor_root = load_metadata(metadata_path)
 
-    install_or_update(base_cmd, env, args.check)
-    parser_dir, info_dir = collect_dirs(base_cmd, env)
-    installed = list_parsers(parser_dir)
-    revisions = list_revisions(info_dir)
-    report(
-        manifest_langs,
-        installed,
-        revisions,
-        check=args.check,
-        prune=args.prune,
-        parser_dir=parser_dir,
-        info_dir=info_dir,
-    )
+    parser_dir = root / "vendor" / "plugins" / "nvim-treesitter" / "parser"
+    info_dir = root / "vendor" / "plugins" / "nvim-treesitter" / "parser-info"
+    suffix = library_suffix()
+
+    if args.check:
+        verify_installation(manifest_langs, metadata, parser_dir, info_dir, suffix=suffix)
+        return
+
+    for lang in manifest_langs:
+        info = metadata.get(lang)
+        if not info:
+            raise SystemExit(
+                f"error: metadata for parser {lang} not found. "
+                "Run scripts/treesitter-vendor.py to refresh vendor sources."
+            )
+        try:
+            build_parser(lang, info, vendor_root, parser_dir, suffix=suffix)
+            write_revision(info_dir, lang, info.get("revision"))
+        except BuildError as exc:
+            raise SystemExit(f"error: {exc}") from exc
+
+    if args.prune:
+        prune_extra(parser_dir, info_dir, suffix, set(manifest_langs))
+
+    verify_installation(manifest_langs, metadata, parser_dir, info_dir, suffix=suffix)
+    log("Parser build complete")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- update treesitter-vendor.py to focus on fetching parser repositories, copying runtime headers, pruning removed languages, and logging progress
- rewrite treesitter-sync.py to build parsers from vendored sources, install artifacts into the local nvim-treesitter plugin, manage revision metadata, and provide clear logging

## Testing
- python -m compileall scripts/treesitter-vendor.py scripts/treesitter-sync.py

------
https://chatgpt.com/codex/tasks/task_e_68d18e0f3bac8331b4e9e65c28db0fe4