### PR TITLE
Use vendored nvim-tree plugin

### DIFF
--- a/nvim/lua/plugins/nvim-tree.lua
+++ b/nvim/lua/plugins/nvim-tree.lua
@@ -1,7 +1,10 @@
+local util = require("config.util")
+
 return {
-  "nvim-tree/nvim-tree.lua",
+  name = "nvim-tree.lua",
+  dir = util.vendor("nvim-tree.lua"),
   dependencies = {
-    "nvim-tree/nvim-web-devicons",
+    "nvim-web-devicons",
   },
   cmd = {
     "NvimTreeToggle",


### PR DESCRIPTION
## Summary
- load nvim-tree from the vendored plugin directory so Lazy does not fetch it from the network
- keep the dependency on nvim-web-devicons using the local plugin name

## Testing
- `NVIM_APPNAME=nvim nvim --headless "+lua print('ok')" +quit` *(fails: nvim not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d2a45222808331abc936c81f849b17