### PR TITLE
Fix explorer disabled by netrw override

### DIFF
--- a/nvim/lua/plugins/nvim-tree.lua
+++ b/nvim/lua/plugins/nvim-tree.lua
@@ -20,10 +20,6 @@ return {
       desc = "Toggle file explorer",
     },
   },
-  init = function()
-    vim.g.loaded_netrw = 1
-    vim.g.loaded_netrwPlugin = 1
-  end,
   config = function()
     require("nvim-tree").setup({
       disable_netrw = false,


### PR DESCRIPTION
## Summary
- remove the manual disabling of netrw so directory buffers open in the default explorer

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d2b1058c2c8331a2aa14166aefc8f1