### PR TITLE
fix: auto-open nvim-tree when editing directories

### DIFF
--- a/nvim/lua/plugins/nvim-tree.lua
+++ b/nvim/lua/plugins/nvim-tree.lua
@@ -6,6 +6,37 @@ return {
   dependencies = {
     "nvim-web-devicons",
   },
+  init = function()
+    local group = vim.api.nvim_create_augroup("nvim_tree_auto_open", { clear = true })
+
+    vim.api.nvim_create_autocmd("VimEnter", {
+      group = group,
+      callback = function(data)
+        local path = data.file or ""
+        if path == "" or vim.fn.isdirectory(path) ~= 1 then
+          return
+        end
+
+        vim.cmd.cd(path)
+        require("lazy").load({ plugins = { "nvim-tree.lua" } })
+        require("nvim-tree.api").tree.open()
+      end,
+    })
+
+    vim.api.nvim_create_autocmd("BufEnter", {
+      group = group,
+      callback = function(data)
+        local path = data.file or ""
+        if path == "" or vim.fn.isdirectory(path) ~= 1 then
+          return
+        end
+
+        require("lazy").load({ plugins = { "nvim-tree.lua" } })
+        require("nvim-tree.api").tree.open()
+        pcall(vim.api.nvim_buf_delete, data.buf, { force = true })
+      end,
+    })
+  end,
   cmd = {
     "NvimTreeToggle",
     "NvimTreeFocus",


### PR DESCRIPTION
## Summary
- add autocommands to eagerly load nvim-tree when editing directories
- ensure directory buffers are replaced by the file explorer

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d2b281a7d08331a0c52038e90d22b7