### PR TITLE
Silence git detached HEAD warning when pinning revisions

### DIFF
--- a/scripts/treesitter-vendor.py
+++ b/scripts/treesitter-vendor.py
@@ -206,7 +206,13 @@ def git_clone(url: str, dest: Path, branch: str | None, revision: str | None) ->
 
     if revision:
         try:
-            checkout_cmd = ["git", "checkout", revision]
+            checkout_cmd = [
+                "git",
+                "-c",
+                "advice.detachedHead=false",
+                "checkout",
+                revision,
+            ]
             log(f"[vendor] Running: (cwd={dest}) {format_command(checkout_cmd)}")
             subprocess.run(checkout_cmd, cwd=dest, check=True)
         except subprocess.CalledProcessError as exc:


### PR DESCRIPTION
## Summary
- suppress the detached HEAD advisory when checking out pinned tree-sitter revisions in the vendor script

## Testing
- python -m compileall scripts/treesitter-vendor.py

------
https://chatgpt.com/codex/tasks/task_e_68d2d7196a8c8331be869b20bb043433