### PR TITLE
Add nvim-gdb debugging plugin

### DIFF
--- a/nvim/lua/plugins/nvim-gdb.lua
+++ b/nvim/lua/plugins/nvim-gdb.lua
@@ -1,0 +1,7 @@
+local util = require("config.util")
+
+return {
+  name = "nvim-gdb",
+  dir = util.vendor("nvim-gdb"),
+  event = "VeryLazy",
+}

--- a/scripts/plugins-list.yaml
+++ b/scripts/plugins-list.yaml
@@ -88,6 +88,14 @@
     "ref": "master"
   },
   {
+    "category": "debug",
+    "description": "Integration of GDB, LLDB, PDB, and BashDB debugging workflows in Neovim.",
+    "depends": [],
+    "url": "https://github.com/sakhnik/nvim-gdb",
+    "name": "nvim-gdb",
+    "ref": "master"
+  },
+  {
     "category": "terminal",
     "description": "Toggleable floating terminal window for Neovim.",
     "depends": [],


### PR DESCRIPTION
## Summary
- add the nvim-gdb repository to the vendored plugin manifest
- provide a lazy.nvim spec so the debugger integration loads from the vendor snapshot

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d3dc81ad3c8331b86beae6b565b4bb