### PR TITLE
feat: integrate nvim-dap debugging plugins

### DIFF
--- a/nvim/lua/plugins/nvim-dap-ui.lua
+++ b/nvim/lua/plugins/nvim-dap-ui.lua
@@ -1,0 +1,39 @@
+local util = require("config.util")
+
+return {
+  name = "nvim-dap-ui",
+  dir = util.vendor("nvim-dap-ui"),
+  dependencies = {
+    "nvim-dap",
+    "nvim-nio",
+    "nvim-web-devicons",
+  },
+  event = "VeryLazy",
+  config = function()
+    local dap = require("dap")
+    local dapui = require("dapui")
+
+    dapui.setup({})
+
+    dap.listeners.after.event_initialized["dapui_config"] = function()
+      dapui.open({})
+    end
+    dap.listeners.before.event_terminated["dapui_config"] = function()
+      dapui.close({})
+    end
+    dap.listeners.before.event_exited["dapui_config"] = function()
+      dapui.close({})
+    end
+
+    local map = vim.keymap.set
+    local opts = { silent = true }
+
+    map("n", "<leader>du", dapui.toggle, vim.tbl_extend("force", opts, { desc = "DAP Toggle UI" }))
+    map("n", "<leader>de", function()
+      dapui.eval()
+    end, vim.tbl_extend("force", opts, { desc = "DAP Evaluate expression" }))
+    map("v", "<leader>de", function()
+      dapui.eval(nil, { enter = true })
+    end, vim.tbl_extend("force", opts, { desc = "DAP Evaluate selection" }))
+  end,
+}

--- a/nvim/lua/plugins/nvim-dap-virtual-text.lua
+++ b/nvim/lua/plugins/nvim-dap-virtual-text.lua
@@ -1,0 +1,17 @@
+local util = require("config.util")
+
+return {
+  name = "nvim-dap-virtual-text",
+  dir = util.vendor("nvim-dap-virtual-text"),
+  dependencies = {
+    "nvim-dap",
+    "nvim-treesitter",
+  },
+  event = "VeryLazy",
+  config = function()
+    require("nvim-dap-virtual-text").setup({
+      commented = true,
+      highlight_changed_variables = true,
+    })
+  end,
+}

--- a/nvim/lua/plugins/nvim-dap.lua
+++ b/nvim/lua/plugins/nvim-dap.lua
@@ -1,0 +1,33 @@
+local util = require("config.util")
+
+return {
+  name = "nvim-dap",
+  dir = util.vendor("nvim-dap"),
+  event = "VeryLazy",
+  config = function()
+    local dap = require("dap")
+
+    local sign = vim.fn.sign_define
+    sign("DapBreakpoint", { text = "", texthl = "DiagnosticSignError", linehl = "", numhl = "" })
+    sign("DapBreakpointCondition", { text = "", texthl = "DiagnosticSignWarn", linehl = "", numhl = "" })
+    sign("DapBreakpointRejected", { text = "", texthl = "DiagnosticSignHint", linehl = "", numhl = "" })
+    sign("DapStopped", { text = "", texthl = "DiagnosticSignInfo", linehl = "DiagnosticUnderlineInfo", numhl = "" })
+
+    local map = vim.keymap.set
+    local opts = { silent = true }
+
+    map("n", "<F5>", dap.continue, vim.tbl_extend("force", opts, { desc = "DAP Continue" }))
+    map("n", "<F6>", dap.restart, vim.tbl_extend("force", opts, { desc = "DAP Restart" }))
+    map("n", "<F7>", dap.terminate, vim.tbl_extend("force", opts, { desc = "DAP Terminate" }))
+    map("n", "<F10>", dap.step_over, vim.tbl_extend("force", opts, { desc = "DAP Step Over" }))
+    map("n", "<F11>", dap.step_into, vim.tbl_extend("force", opts, { desc = "DAP Step Into" }))
+    map("n", "<F12>", dap.step_out, vim.tbl_extend("force", opts, { desc = "DAP Step Out" }))
+
+    map("n", "<leader>db", dap.toggle_breakpoint, vim.tbl_extend("force", opts, { desc = "DAP Toggle breakpoint" }))
+    map("n", "<leader>dB", function()
+      dap.set_breakpoint(vim.fn.input("Breakpoint condition: "))
+    end, vim.tbl_extend("force", opts, { desc = "DAP Set conditional breakpoint" }))
+    map("n", "<leader>dl", dap.run_last, vim.tbl_extend("force", opts, { desc = "DAP Run last" }))
+    map("n", "<leader>dr", dap.repl.toggle, vim.tbl_extend("force", opts, { desc = "DAP Toggle REPL" }))
+  end,
+}

--- a/nvim/lua/plugins/nvim-nio.lua
+++ b/nvim/lua/plugins/nvim-nio.lua
@@ -1,0 +1,7 @@
+local util = require("config.util")
+
+return {
+  name = "nvim-nio",
+  dir = util.vendor("nvim-nio"),
+  lazy = true,
+}

--- a/scripts/plugins-list.yaml
+++ b/scripts/plugins-list.yaml
@@ -96,6 +96,38 @@
     "ref": "master"
   },
   {
+    "category": "debug",
+    "description": "Debug Adapter Protocol client implementation for Neovim.",
+    "depends": [],
+    "url": "https://github.com/mfussenegger/nvim-dap",
+    "name": "nvim-dap",
+    "ref": "master"
+  },
+  {
+    "category": "debug",
+    "description": "A UI for nvim-dap providing layouts, elements, and controls.",
+    "depends": ["nvim-dap", "nvim-nio", "nvim-web-devicons"],
+    "url": "https://github.com/rcarriga/nvim-dap-ui",
+    "name": "nvim-dap-ui",
+    "ref": "master"
+  },
+  {
+    "category": "debug",
+    "description": "Async IO primitives used by Neovim debug tooling and adapters.",
+    "depends": [],
+    "url": "https://github.com/nvim-neotest/nvim-nio",
+    "name": "nvim-nio",
+    "ref": "main"
+  },
+  {
+    "category": "debug",
+    "description": "Virtual text integration showing nvim-dap variable values inline.",
+    "depends": ["nvim-dap", "nvim-treesitter"],
+    "url": "https://github.com/theHamsta/nvim-dap-virtual-text",
+    "name": "nvim-dap-virtual-text",
+    "ref": "main"
+  },
+  {
     "category": "terminal",
     "description": "Toggleable floating terminal window for Neovim.",
     "depends": [],


### PR DESCRIPTION
## Summary
- add nvim-dap plugin configuration with default signs and keymaps
- configure nvim-dap-ui and nvim-dap-virtual-text support along with nvim-nio dependency
- register the debugging plugins in the vendored plugin manifest

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d3e28a3e308331a32ff847fc30bd5b