### PR TITLE
fix: correct nvim-nio branch

### DIFF
--- a/scripts/plugins-list.yaml
+++ b/scripts/plugins-list.yaml
@@ -117,7 +117,7 @@
     "depends": [],
     "url": "https://github.com/nvim-neotest/nvim-nio",
     "name": "nvim-nio",
-    "ref": "main"
+    "ref": "master"
   },
   {
     "category": "debug",


### PR DESCRIPTION
## Summary
- point the nvim-nio vendoring entry at the repository's master branch

## Testing
- python3 scripts/vendor_update.py --dry-run --only nvim-nio --allow-dirty

------
https://chatgpt.com/codex/tasks/task_e_68d3e4bb600c8331914816e4afd519fa