### PR TITLE
Remove manually vendored git integrations

### DIFF
--- a/nvim/lua/plugins/diffview.lua
+++ b/nvim/lua/plugins/diffview.lua
@@ -1,0 +1,57 @@
+local util = require("config.util")
+
+return {
+  name = "diffview.nvim",
+  dir = util.vendor("diffview.nvim"),
+  cmd = {
+    "DiffviewOpen",
+    "DiffviewClose",
+    "DiffviewToggleFiles",
+    "DiffviewFileHistory",
+  },
+  dependencies = {
+    "plenary.nvim",
+    "nvim-web-devicons",
+  },
+  config = function()
+    local diffview = require("diffview")
+
+    diffview.setup({
+      enhanced_diff_hl = true,
+      view = {
+        default = {
+          layout = "diff2_horizontal",
+        },
+      },
+      file_panel = {
+        win_config = {
+          position = "left",
+          width = 35,
+        },
+      },
+    })
+
+    local map = vim.keymap.set
+    local opts = { noremap = true, silent = true }
+
+    map("n", "<leader>gd", "<cmd>DiffviewOpen<cr>", vim.tbl_extend("force", opts, { desc = "Open Diffview" }))
+    map(
+      "n",
+      "<leader>gD",
+      "<cmd>DiffviewClose<cr>",
+      vim.tbl_extend("force", opts, { desc = "Close Diffview" })
+    )
+    map(
+      "n",
+      "<leader>gh",
+      "<cmd>DiffviewFileHistory %<cr>",
+      vim.tbl_extend("force", opts, { desc = "File history" })
+    )
+    map(
+      "n",
+      "<leader>gH",
+      "<cmd>DiffviewFileHistory<cr>",
+      vim.tbl_extend("force", opts, { desc = "Repository history" })
+    )
+  end,
+}

--- a/nvim/lua/plugins/git-worktree.lua
+++ b/nvim/lua/plugins/git-worktree.lua
@@ -1,0 +1,59 @@
+local util = require("config.util")
+
+return {
+  name = "git-worktree.nvim",
+  dir = util.vendor("git-worktree.nvim"),
+  dependencies = {
+    "plenary.nvim",
+    "telescope.nvim",
+  },
+  config = function()
+    local worktree = require("git-worktree")
+
+    worktree.setup({})
+
+    local telescope = require("telescope")
+    pcall(telescope.load_extension, "git_worktree")
+
+    local extension = telescope.extensions and telescope.extensions.git_worktree
+    local function ensure_extension()
+      if extension then
+        return true
+      end
+
+      local ok = pcall(telescope.load_extension, "git_worktree")
+      if ok then
+        extension = telescope.extensions.git_worktree
+      else
+        vim.notify("git-worktree telescope extension unavailable", vim.log.levels.ERROR)
+      end
+
+      return extension ~= nil
+    end
+
+    local map = vim.keymap.set
+    local opts = { noremap = true, silent = true }
+
+    map(
+      "n",
+      "<leader>gwt",
+      function()
+        if ensure_extension() then
+          extension.git_worktrees()
+        end
+      end,
+      vim.tbl_extend("force", opts, { desc = "Switch Git worktree" })
+    )
+
+    map(
+      "n",
+      "<leader>gwc",
+      function()
+        if ensure_extension() then
+          extension.create_git_worktree()
+        end
+      end,
+      vim.tbl_extend("force", opts, { desc = "Create Git worktree" })
+    )
+  end,
+}

--- a/nvim/lua/plugins/lazygit.lua
+++ b/nvim/lua/plugins/lazygit.lua
@@ -1,0 +1,28 @@
+local util = require("config.util")
+
+return {
+  name = "lazygit.nvim",
+  dir = util.vendor("lazygit.nvim"),
+  cmd = {
+    "LazyGit",
+    "LazyGitConfig",
+    "LazyGitCurrentFile",
+    "LazyGitFilter",
+    "LazyGitFilterCurrentFile",
+  },
+  dependencies = {
+    "plenary.nvim",
+  },
+  config = function()
+    local map = vim.keymap.set
+    local opts = { noremap = true, silent = true }
+
+    map("n", "<leader>gg", "<cmd>LazyGit<cr>", vim.tbl_extend("force", opts, { desc = "Open Lazygit" }))
+    map(
+      "n",
+      "<leader>gG",
+      "<cmd>LazyGitCurrentFile<cr>",
+      vim.tbl_extend("force", opts, { desc = "Open Lazygit for current file" })
+    )
+  end,
+}

--- a/scripts/plugins-list.yaml
+++ b/scripts/plugins-list.yaml
@@ -40,6 +40,14 @@
     "ref": "main"
   },
   {
+    "category": "git",
+    "description": "Floating terminal integration for the Lazygit TUI inside Neovim.",
+    "depends": ["plenary.nvim"],
+    "url": "https://github.com/kdheepak/lazygit.nvim",
+    "name": "lazygit.nvim",
+    "ref": "main"
+  },
+  {
     "category": "library",
     "description": "Utility Lua functions used by many Neovim plugins.",
     "depends": [],
@@ -72,6 +80,14 @@
     "ref": "master"
   },
   {
+    "category": "git",
+    "description": "Scoped Git worktree management with Telescope integration.",
+    "depends": ["plenary.nvim", "telescope.nvim"],
+    "url": "https://github.com/ThePrimeagen/git-worktree.nvim",
+    "name": "git-worktree.nvim",
+    "ref": "master"
+  },
+  {
     "category": "snippets",
     "description": "Snippets engine written in Lua with advanced features.",
     "depends": [],
@@ -86,6 +102,14 @@
     "url": "https://github.com/nvim-treesitter/nvim-treesitter",
     "name": "nvim-treesitter",
     "ref": "master"
+  },
+  {
+    "category": "git",
+    "description": "Single-tabpage interface for reviewing Git changes inside Neovim.",
+    "depends": ["plenary.nvim", "nvim-web-devicons"],
+    "url": "https://github.com/sindrets/diffview.nvim",
+    "name": "diffview.nvim",
+    "ref": "main"
   },
   {
     "category": "debug",


### PR DESCRIPTION
## Summary
- remove the manually vendored lazygit.nvim, diffview.nvim, and git-worktree.nvim trees per repository guidelines

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d3e8033a3c83319030b9695cec90c0