### PR TITLE
fix: restore backslash leader key

### DIFF
--- a/nvim/init.lua
+++ b/nvim/init.lua
@@ -1,6 +1,6 @@
--- Set <Space> as the leader key before lazy loads plugins
-vim.g.mapleader = " "
-vim.g.maplocalleader = " "
+-- Restore Neovim's default backslash leader before loading plugins
+vim.g.mapleader = "\\"
+vim.g.maplocalleader = "\\"
 
 -- Apply basic options and keymaps
 require("config.options")

--- a/nvim/lua/plugins/toggleterm.lua
+++ b/nvim/lua/plugins/toggleterm.lua
@@ -6,6 +6,7 @@ return {
   cmd = { "ToggleTerm", "TermExec" },
   keys = {
     { "<leader>tt", "<cmd>ToggleTerm<cr>", desc = "Toggle terminal" },
+    { [[\tt]], "<cmd>ToggleTerm<cr>", mode = "n", desc = "Toggle terminal" },
   },
   config = function()
     require("toggleterm").setup({
@@ -20,7 +21,5 @@ return {
         winblend = 3,
       },
     })
-
-    vim.keymap.set("n", "<leader>tt", "<cmd>ToggleTerm<cr>", { desc = "Toggle terminal" })
   end,
 }


### PR DESCRIPTION
## Summary
- restore the default backslash leader and localleader assignments
- add an explicit normal-mode `\tt` mapping so ToggleTerm opens with the backslash sequence as well as `<leader>tt`

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d3efa90ec08331a5a003bb9dbf6615