### PR TITLE
refactor: simplify external tool resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,39 @@ By default the installer creates a symbolic link from `<repo>/nvim` to your Neov
 
 After linking you can start Neovim immediately, even on an offline machine.
 
+## 🔧 External Tool Configuration
+
+The configuration shells out to a handful of external binaries (Git, debuggers, search utilities, language servers, build tools, …).
+`nvim/lua/config/tools.lua` exposes one helper per binary (`tools.git()`, `tools.lazygit()`, `tools.ripgrep()`, `tools.lua_ls()`, and so on)
+so every plugin reads from the same source of truth.
+
+Each helper follows the same resolution order:
+
+1. honour `$NVIM_PRO_KIT_<TOOL>` when it is set (the variable must point at the executable);
+2. probe platform-specific defaults for the current machine (Linux x86_64, Linux aarch64, macOS x86_64, and macOS arm64);
+3. fall back to whatever the system exposes on `$PATH`.
+
+Whenever the helper returns an absolute path its parent directory is prepended to `$PATH` automatically so vendored plugins can spawn
+the tool without additional configuration.
+
+The module currently resolves the following tools:
+
+- `git`, `lazygit`, and `hg`;
+- `ripgrep` (`rg`);
+- `python` (debugpy);
+- `node`, `npm`, and the Tree-sitter CLI;
+- `make` (used to build native Telescope/LuaSnip components);
+- `gdb`;
+- language servers: `lua_ls`, `pyright`, `ts_ls`;
+- compiler candidates for Tree-sitter builds via `tools.compilers()`.
+
+Set `NVIM_PRO_KIT_<TOOL>` (for example `NVIM_PRO_KIT_GIT`, `NVIM_PRO_KIT_LAZYGIT`, `NVIM_PRO_KIT_RIPGREP`, …) to point at custom
+executables without editing the repository.
+
+Set `NVIM_PRO_KIT_COMPILERS` to a path-separated list if you need to override the compiler search order; otherwise the helper prefers
+`cc`/`gcc`/`clang` on Linux and `clang`/`cc` on macOS. Adjust the platform-specific paths inside `tools.lua` if you install binaries in
+non-standard locations.
+
 ## 📦 Managing Vendored Plugins
 
 This repository vendors every Neovim plugin under `vendor/plugins/` using `git subtree`. There are no submodules, runtime downloads, or hidden network calls.

--- a/nvim/init.lua
+++ b/nvim/init.lua
@@ -6,6 +6,9 @@ vim.g.maplocalleader = "\\"
 require("config.options")
 require("config.keymaps")
 
+-- Discover external tool locations before loading plugins
+require("config.tools").setup()
+
 -- Bootstrap lazy.nvim from the vendored plugins directory and load plugins
 require("config.lazy")
 

--- a/nvim/lua/config/tools.lua
+++ b/nvim/lua/config/tools.lua
@@ -1,0 +1,383 @@
+local M = {}
+
+local uv = vim.uv or vim.loop
+local dir_separator = package.config:sub(1, 1)
+local path_separator = package.config:sub(3, 3)
+
+local function detect_platform()
+  local uname = (uv and uv.os_uname and uv.os_uname()) or {}
+  local sysname = (uname.sysname or ""):lower()
+  local machine = (uname.machine or ""):lower()
+
+  if sysname:find("linux") then
+    if machine == "x86_64" or machine == "amd64" then
+      return "linux_x86_64"
+    elseif machine == "aarch64" or machine == "arm64" then
+      return "linux_aarch64"
+    end
+    return "linux"
+  elseif sysname:find("darwin") then
+    if machine == "x86_64" then
+      return "macos_x86_64"
+    elseif machine == "arm64" then
+      return "macos_arm64"
+    end
+    return "macos"
+  end
+
+  return "unknown"
+end
+
+local platform = detect_platform()
+
+local function mason_tool(name)
+  local base = vim.fn.stdpath("data")
+  if not base or base == "" then
+    return nil
+  end
+  return vim.fs.normalize(base .. "/mason/bin/" .. name)
+end
+
+local function ensure_dir_on_path(path)
+  if not path or path == "" then
+    return
+  end
+
+  if not path:find(dir_separator, 1, true) then
+    return
+  end
+
+  local dir = vim.fs.dirname(path)
+  if not dir or dir == "" then
+    return
+  end
+
+  local current = vim.env.PATH or ""
+  for entry in string.gmatch(current, "[^" .. path_separator .. "]+") do
+    if entry == dir then
+      return
+    end
+  end
+
+  if current == "" then
+    vim.env.PATH = dir
+  else
+    vim.env.PATH = dir .. path_separator .. current
+  end
+end
+
+local function normalize(candidate)
+  if not candidate or candidate == "" then
+    return nil
+  end
+
+  local expanded = vim.fn.expand(candidate)
+  if expanded:find(dir_separator, 1, true) then
+    if vim.fn.executable(expanded) == 1 then
+      return vim.fs.normalize(expanded)
+    end
+    return nil
+  end
+
+  local resolved = vim.fn.exepath(expanded)
+  if resolved and resolved ~= "" then
+    return resolved
+  end
+end
+
+local function extend(list, value)
+  if not value then
+    return
+  end
+  if type(value) == "string" then
+    table.insert(list, value)
+  elseif type(value) == "table" then
+    for _, item in ipairs(value) do
+      if item and item ~= "" then
+        table.insert(list, item)
+      end
+    end
+  end
+end
+
+local function resolve(env_name, platform_candidates, fallback)
+  local env_value = vim.env[env_name]
+  local env_path = normalize(env_value)
+  if env_path then
+    ensure_dir_on_path(env_path)
+    return env_path
+  end
+
+  local candidates = {}
+
+  if type(platform_candidates) == "table" then
+    extend(candidates, platform_candidates[platform])
+    extend(candidates, platform_candidates.default)
+  elseif type(platform_candidates) == "string" then
+    extend(candidates, platform_candidates)
+  end
+
+  extend(candidates, fallback)
+
+  for _, candidate in ipairs(candidates) do
+    local resolved = normalize(candidate)
+    if resolved then
+      ensure_dir_on_path(resolved)
+      return resolved
+    end
+  end
+
+  return nil
+end
+
+local cache = {}
+local resolvers = {}
+
+local function define(name, resolver)
+  local function wrapped()
+    if cache[name] == nil then
+      cache[name] = resolver()
+    end
+    return cache[name]
+  end
+  M[name] = wrapped
+  resolvers[name] = wrapped
+end
+
+define("git", function()
+  return resolve("NVIM_PRO_KIT_GIT", {
+    linux_x86_64 = { "/usr/bin/git", "/usr/local/bin/git" },
+    linux_aarch64 = { "/usr/bin/git", "/usr/local/bin/git" },
+    macos_x86_64 = { "/usr/local/bin/git" },
+    macos_arm64 = { "/opt/homebrew/bin/git" },
+  }, { "git" })
+end)
+
+define("lazygit", function()
+  return resolve("NVIM_PRO_KIT_LAZYGIT", {
+    linux_x86_64 = { "/usr/bin/lazygit", "/usr/local/bin/lazygit" },
+    linux_aarch64 = { "/usr/bin/lazygit", "/usr/local/bin/lazygit" },
+    macos_x86_64 = { "/usr/local/bin/lazygit" },
+    macos_arm64 = { "/opt/homebrew/bin/lazygit" },
+  }, { "lazygit" })
+end)
+
+define("ripgrep", function()
+  return resolve("NVIM_PRO_KIT_RIPGREP", {
+    linux_x86_64 = { "/usr/bin/rg", "/usr/local/bin/rg" },
+    linux_aarch64 = { "/usr/bin/rg", "/usr/local/bin/rg" },
+    macos_x86_64 = { "/usr/local/bin/rg" },
+    macos_arm64 = { "/opt/homebrew/bin/rg" },
+  }, { "rg" })
+end)
+
+define("python", function()
+  return resolve("NVIM_PRO_KIT_PYTHON", {
+    linux_x86_64 = { "/usr/bin/python3", "/usr/bin/python" },
+    linux_aarch64 = { "/usr/bin/python3", "/usr/bin/python" },
+    macos_x86_64 = { "/usr/local/bin/python3", "/usr/bin/python3" },
+    macos_arm64 = { "/opt/homebrew/bin/python3", "/usr/bin/python3" },
+  }, { "python3", "python" })
+end)
+
+define("node", function()
+  return resolve("NVIM_PRO_KIT_NODE", {
+    linux_x86_64 = { "/usr/bin/node", "/usr/local/bin/node" },
+    linux_aarch64 = { "/usr/bin/node", "/usr/local/bin/node" },
+    macos_x86_64 = { "/usr/local/bin/node" },
+    macos_arm64 = { "/opt/homebrew/bin/node" },
+  }, { "node" })
+end)
+
+define("npm", function()
+  return resolve("NVIM_PRO_KIT_NPM", {
+    linux_x86_64 = { "/usr/bin/npm", "/usr/local/bin/npm" },
+    linux_aarch64 = { "/usr/bin/npm", "/usr/local/bin/npm" },
+    macos_x86_64 = { "/usr/local/bin/npm" },
+    macos_arm64 = { "/opt/homebrew/bin/npm" },
+  }, { "npm" })
+end)
+
+define("tree_sitter", function()
+  return resolve("NVIM_PRO_KIT_TREE_SITTER", {
+    linux_x86_64 = { "/usr/bin/tree-sitter", "/usr/local/bin/tree-sitter" },
+    linux_aarch64 = { "/usr/bin/tree-sitter", "/usr/local/bin/tree-sitter" },
+    macos_x86_64 = { "/usr/local/bin/tree-sitter" },
+    macos_arm64 = { "/opt/homebrew/bin/tree-sitter" },
+  }, { "tree-sitter" })
+end)
+
+define("make", function()
+  return resolve("NVIM_PRO_KIT_MAKE", {
+    linux_x86_64 = { "/usr/bin/make", "/usr/local/bin/make" },
+    linux_aarch64 = { "/usr/bin/make", "/usr/local/bin/make" },
+    macos_x86_64 = { "/usr/local/bin/gmake", "/usr/bin/make" },
+    macos_arm64 = { "/opt/homebrew/bin/gmake", "/usr/bin/make" },
+  }, { "gmake", "make" })
+end)
+
+define("gdb", function()
+  return resolve("NVIM_PRO_KIT_GDB", {
+    linux_x86_64 = { "/usr/bin/gdb", "/usr/local/bin/gdb" },
+    linux_aarch64 = { "/usr/bin/gdb", "/usr/local/bin/gdb" },
+    macos_x86_64 = { "/usr/local/bin/gdb" },
+    macos_arm64 = { "/opt/homebrew/bin/gdb" },
+  }, { "gdb" })
+end)
+
+define("lua_ls", function()
+  local mason = mason_tool("lua-language-server")
+  return resolve("NVIM_PRO_KIT_LUA_LS", {
+    linux_x86_64 = { "/usr/bin/lua-language-server", mason },
+    linux_aarch64 = { "/usr/bin/lua-language-server", mason },
+    macos_x86_64 = { "/usr/local/bin/lua-language-server", mason },
+    macos_arm64 = { "/opt/homebrew/bin/lua-language-server", mason },
+  }, { mason, "lua-language-server" })
+end)
+
+define("pyright", function()
+  local mason = mason_tool("pyright-langserver")
+  return resolve("NVIM_PRO_KIT_PYRIGHT", {
+    linux_x86_64 = { "/usr/bin/pyright-langserver", "/usr/local/bin/pyright-langserver", mason },
+    linux_aarch64 = { "/usr/bin/pyright-langserver", "/usr/local/bin/pyright-langserver", mason },
+    macos_x86_64 = { "/usr/local/bin/pyright-langserver", mason },
+    macos_arm64 = { "/opt/homebrew/bin/pyright-langserver", mason },
+  }, { mason, "pyright-langserver" })
+end)
+
+define("ts_ls", function()
+  local mason = mason_tool("typescript-language-server")
+  return resolve("NVIM_PRO_KIT_TS_LS", {
+    linux_x86_64 = { "/usr/bin/typescript-language-server", "/usr/local/bin/typescript-language-server", mason },
+    linux_aarch64 = { "/usr/bin/typescript-language-server", "/usr/local/bin/typescript-language-server", mason },
+    macos_x86_64 = { "/usr/local/bin/typescript-language-server", mason },
+    macos_arm64 = { "/opt/homebrew/bin/typescript-language-server", mason },
+  }, { mason, "typescript-language-server" })
+end)
+
+define("hg", function()
+  return resolve("NVIM_PRO_KIT_HG", {
+    linux_x86_64 = { "/usr/bin/hg", "/usr/local/bin/hg" },
+    linux_aarch64 = { "/usr/bin/hg", "/usr/local/bin/hg" },
+    macos_x86_64 = { "/usr/local/bin/hg" },
+    macos_arm64 = { "/opt/homebrew/bin/hg" },
+  }, { "hg" })
+end)
+
+local lsp_args = {
+  lua_ls = {},
+  pyright = { "--stdio" },
+  ts_ls = { "--stdio" },
+}
+
+function M.binary(tool)
+  local resolver = resolvers[tool]
+  if not resolver then
+    return nil
+  end
+  return resolver()
+end
+
+function M.has(tool)
+  return M.binary(tool) ~= nil
+end
+
+function M.ensure_on_path(tool)
+  return M.binary(tool)
+end
+
+function M.lsp_cmd(server)
+  local binary = M.binary(server)
+  if not binary then
+    return nil
+  end
+
+  local cmd = { binary }
+  for _, arg in ipairs(lsp_args[server] or {}) do
+    table.insert(cmd, arg)
+  end
+  return cmd
+end
+
+function M.python()
+  return resolvers.python()
+end
+
+function M.ripgrep_arguments()
+  local rg = M.ripgrep() or "rg"
+  return {
+    rg,
+    "--color=never",
+    "--no-heading",
+    "--with-filename",
+    "--line-number",
+    "--column",
+    "--smart-case",
+  }
+end
+
+function M.compilers()
+  local env = vim.env.NVIM_PRO_KIT_COMPILERS
+  if env and env ~= "" then
+    local list = vim.split(env, path_separator, { trimempty = true })
+    local resolved = {}
+    for _, entry in ipairs(list) do
+      local candidate = normalize(entry)
+      table.insert(resolved, candidate or entry)
+    end
+    if #resolved > 0 then
+      return resolved
+    end
+  end
+
+  local defaults = {
+    linux_x86_64 = { "cc", "gcc", "clang" },
+    linux_aarch64 = { "cc", "gcc", "clang" },
+    macos_x86_64 = { "clang", "cc" },
+    macos_arm64 = { "clang", "cc" },
+  }
+
+  local candidates = defaults[platform] or { "cc", "gcc", "clang" }
+  local resolved = {}
+  for _, candidate in ipairs(candidates) do
+    local path = normalize(candidate)
+    table.insert(resolved, path or candidate)
+  end
+
+  return resolved
+end
+
+function M.run(tool, args, cwd)
+  local binary = M.binary(tool)
+  if not binary then
+    return false, string.format("Tool '%s' is not available", tool)
+  end
+
+  local command = { binary }
+  if args and #args > 0 then
+    vim.list_extend(command, args)
+  end
+
+  if vim.system then
+    local result = vim.system(command, { cwd = cwd }):wait()
+    local success = result.code == 0
+    local stderr = result.stderr or ""
+    local stdout = result.stdout or ""
+    local message = stderr ~= "" and stderr or stdout
+    return success, message
+  end
+
+  local output = vim.fn.system(command)
+  local success = vim.v.shell_error == 0
+  return success, output
+end
+
+function M.setup()
+  for _, resolver in pairs(resolvers) do
+    resolver()
+  end
+  M.compilers()
+  return M
+end
+
+return M

--- a/nvim/lua/plugins/diffview.lua
+++ b/nvim/lua/plugins/diffview.lua
@@ -1,4 +1,5 @@
 local util = require("config.util")
+local tools = require("config.tools")
 
 return {
   name = "diffview.nvim",
@@ -16,7 +17,12 @@ return {
   config = function()
     local diffview = require("diffview")
 
+    local git_cmd = { tools.git() or "git" }
+    local hg = tools.hg()
+
     diffview.setup({
+      git_cmd = git_cmd,
+      hg_cmd = hg and { hg } or nil,
       enhanced_diff_hl = true,
       view = {
         default = {

--- a/nvim/lua/plugins/git-worktree.lua
+++ b/nvim/lua/plugins/git-worktree.lua
@@ -1,4 +1,5 @@
 local util = require("config.util")
+local tools = require("config.tools")
 
 return {
   name = "git-worktree.nvim",
@@ -7,6 +8,9 @@ return {
     "plenary.nvim",
     "telescope.nvim",
   },
+  init = function()
+    tools.git()
+  end,
   config = function()
     local worktree = require("git-worktree")
 

--- a/nvim/lua/plugins/gitsigns.lua
+++ b/nvim/lua/plugins/gitsigns.lua
@@ -1,4 +1,5 @@
 local util = require("config.util")
+local tools = require("config.tools")
 
 return {
   name = "gitsigns.nvim",
@@ -8,7 +9,10 @@ return {
     "plenary.nvim",
   },
   config = function()
+    local git_binary = tools.git() or "git"
+
     require("gitsigns").setup({
+      git_cmd = { git_binary },
       signs = {
         add = { text = "▎" },
         change = { text = "▎" },

--- a/nvim/lua/plugins/lazygit.lua
+++ b/nvim/lua/plugins/lazygit.lua
@@ -1,4 +1,5 @@
 local util = require("config.util")
+local tools = require("config.tools")
 
 return {
   name = "lazygit.nvim",
@@ -10,6 +11,9 @@ return {
     "LazyGitFilter",
     "LazyGitFilterCurrentFile",
   },
+  init = function()
+    tools.lazygit()
+  end,
   dependencies = {
     "plenary.nvim",
   },

--- a/nvim/lua/plugins/luasnip.lua
+++ b/nvim/lua/plugins/luasnip.lua
@@ -1,10 +1,16 @@
 local util = require("config.util")
+local tools = require("config.tools")
 
 return {
   name = "LuaSnip",
   dir = util.vendor("LuaSnip"),
   version = "*",
-  build = (vim.fn.executable("make") == 1) and "make install_jsregexp" or nil,
+  build = function(plugin)
+    local ok, message = tools.run("make", { "install_jsregexp" }, plugin.dir)
+    if not ok then
+      vim.notify("LuaSnip build failed: " .. (message or "unknown error"), vim.log.levels.WARN)
+    end
+  end,
   config = function()
     local luasnip = require("luasnip")
 

--- a/nvim/lua/plugins/nvim-dap-python.lua
+++ b/nvim/lua/plugins/nvim-dap-python.lua
@@ -1,54 +1,5 @@
 local util = require("config.util")
-local uv = vim.uv or vim.loop
-
-local function python_path()
-  local fn = vim.fn
-  local is_windows = fn.has("win32") == 1
-
-  local function venv_python(root)
-    if not root or root == "" then
-      return nil
-    end
-
-    local executable = is_windows and "python.exe" or "python3"
-    local subdir = is_windows and "Scripts" or "bin"
-    local candidate = vim.fs.joinpath(root, subdir, executable)
-    if fn.executable(candidate) == 1 then
-      return candidate
-    end
-  end
-
-  local environment_vars = { "VIRTUAL_ENV", "CONDA_PREFIX", "PYENV_VIRTUALENV" }
-  for _, name in ipairs(environment_vars) do
-    local from_env = venv_python(vim.env[name])
-    if from_env then
-      return from_env
-    end
-  end
-
-  local cwd = (uv and uv.cwd and uv.cwd()) or fn.getcwd()
-  if cwd and cwd ~= "" then
-    local workspace_roots = { ".venv", "venv", ".env" }
-    for _, root in ipairs(workspace_roots) do
-      local from_workspace = venv_python(vim.fs.joinpath(cwd, root))
-      if from_workspace then
-        return from_workspace
-      end
-    end
-  end
-
-  local executable = fn.exepath("python3")
-  if executable and executable ~= "" then
-    return executable
-  end
-
-  executable = fn.exepath("python")
-  if executable and executable ~= "" then
-    return executable
-  end
-
-  return is_windows and "python.exe" or "python3"
-end
+local tools = require("config.tools")
 
 return {
   name = "nvim-dap-python",
@@ -58,7 +9,7 @@ return {
   config = function()
     local dap_python = require("dap-python")
 
-    dap_python.setup(python_path())
+    dap_python.setup(tools.python())
 
     local map = vim.keymap.set
     local opts = { silent = true }

--- a/nvim/lua/plugins/nvim-gdb.lua
+++ b/nvim/lua/plugins/nvim-gdb.lua
@@ -1,7 +1,11 @@
 local util = require("config.util")
+local tools = require("config.tools")
 
 return {
   name = "nvim-gdb",
   dir = util.vendor("nvim-gdb"),
   event = "VeryLazy",
+  init = function()
+    tools.gdb()
+  end,
 }

--- a/nvim/lua/plugins/nvim-lspconfig.lua
+++ b/nvim/lua/plugins/nvim-lspconfig.lua
@@ -1,4 +1,5 @@
 local util = require("config.util")
+local tools = require("config.tools")
 
 return {
   name = "nvim-lspconfig",
@@ -34,6 +35,7 @@ return {
 
     local servers = {
       lua_ls = {
+        cmd = tools.lsp_cmd("lua_ls"),
         settings = {
           Lua = {
             runtime = {
@@ -50,8 +52,12 @@ return {
           },
         },
       },
-      pyright = {},
-      ts_ls = {},
+      pyright = {
+        cmd = tools.lsp_cmd("pyright"),
+      },
+      ts_ls = {
+        cmd = tools.lsp_cmd("ts_ls"),
+      },
     }
 
     for server, config in pairs(servers) do

--- a/nvim/lua/plugins/nvim-treesitter.lua
+++ b/nvim/lua/plugins/nvim-treesitter.lua
@@ -1,4 +1,5 @@
 local util = require("config.util")
+local tools = require("config.tools")
 local manifest = require("config.treesitter_manifest")
 local vendor = require("config.treesitter_vendor")
 
@@ -9,6 +10,9 @@ return {
   config = function()
     local ensure_installed = manifest.languages()
     vendor.apply(ensure_installed)
+
+    local install = require("nvim-treesitter.install")
+    install.compilers = tools.compilers()
 
     require("nvim-treesitter.configs").setup({
       -- Update scripts/treesitter-parsers.txt and run scripts/treesitter-sync.py

--- a/nvim/lua/plugins/telescope-fzf-native.lua
+++ b/nvim/lua/plugins/telescope-fzf-native.lua
@@ -1,10 +1,16 @@
 local util = require("config.util")
+local tools = require("config.tools")
 
 return {
   name = "telescope-fzf-native.nvim",
   dir = util.vendor("telescope-fzf-native.nvim"),
-  build = "make",
+  build = function(plugin)
+    local ok, message = tools.run("make", nil, plugin.dir)
+    if not ok then
+      vim.notify("telescope-fzf-native build failed: " .. (message or "unknown error"), vim.log.levels.WARN)
+    end
+  end,
   cond = function()
-    return vim.fn.executable("make") == 1
+    return tools.has("make")
   end,
 }

--- a/nvim/lua/plugins/telescope.lua
+++ b/nvim/lua/plugins/telescope.lua
@@ -1,4 +1,5 @@
 local util = require("config.util")
+local tools = require("config.tools")
 
 return {
   name = "telescope.nvim",
@@ -15,6 +16,7 @@ return {
 
     telescope.setup({
       defaults = {
+        vimgrep_arguments = tools.ripgrep_arguments(),
         prompt_prefix = "  ",
         selection_caret = "  ",
         path_display = { "smart" },


### PR DESCRIPTION
## Summary
- replace `config.tools` with per-tool helpers that honour NVIM_PRO_KIT_* overrides, platform defaults, and PATH lookups
- update plugin integrations to use the new helpers for Git, Lazygit, Diffview, nvim-gdb, and telescope tooling
- document the streamlined tool resolution workflow and environment variables in the README

## Testing
- `nvim --headless -u nvim/init.lua +qa` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d3f7e8e0788331979532e97632fd41