### PR TITLE
Refactor tool definitions into dedicated module

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ After linking you can start Neovim immediately, even on an offline machine.
 ## 🔧 External Tool Configuration
 
 The configuration shells out to a handful of external binaries (Git, debuggers, search utilities, language servers, build tools, …).
-`nvim/lua/config/tools.lua` exposes one helper per binary (`tools.git()`, `tools.lazygit()`, `tools.ripgrep()`, `tools.lua_ls()`, and so on)
+The `config.tools` module (see `nvim/lua/config/tools/`) exposes one helper per binary (`tools.git()`, `tools.lazygit()`, `tools.ripgrep()`, `tools.lua_ls()`, and so on)
 so every plugin reads from the same source of truth.
 
 Each helper follows the same resolution order:
@@ -73,7 +73,7 @@ Set `NVIM_PRO_KIT_<TOOL>` (for example `NVIM_PRO_KIT_GIT`, `NVIM_PRO_KIT_LAZYGIT
 executables without editing the repository.
 
 Set `NVIM_PRO_KIT_COMPILERS` to a path-separated list if you need to override the compiler search order; otherwise the helper prefers
-`cc`/`gcc`/`clang` on Linux and `clang`/`cc` on macOS. Adjust the platform-specific paths inside `tools.lua` if you install binaries in
+`cc`/`gcc`/`clang` on Linux and `clang`/`cc` on macOS. Adjust the platform-specific paths inside `nvim/lua/config/tools/definitions.lua` if you install binaries in
 non-standard locations.
 
 ## 📦 Managing Vendored Plugins

--- a/nvim/lua/config/tools/definitions.lua
+++ b/nvim/lua/config/tools/definitions.lua
@@ -1,0 +1,216 @@
+return function(api)
+  local define = api.define
+  local resolve = api.resolve
+  local mason_tool = api.mason_tool
+
+  define(
+    "git",
+    function()
+      return resolve("NVIM_PRO_KIT_GIT", {
+        linux_x86_64 = { "/usr/bin/git", "/usr/local/bin/git" },
+        linux_aarch64 = { "/usr/bin/git", "/usr/local/bin/git" },
+        macos_x86_64 = { "/usr/local/bin/git" },
+        macos_arm64 = { "/opt/homebrew/bin/git" },
+      }, { "git" })
+    end,
+    {
+      description = "Git distributed version control system.",
+      plugins = { "git-worktree.nvim", "gitsigns.nvim", "diffview.nvim" },
+    }
+  )
+
+  define(
+    "lazygit",
+    function()
+      return resolve("NVIM_PRO_KIT_LAZYGIT", {
+        linux_x86_64 = { "/usr/bin/lazygit", "/usr/local/bin/lazygit" },
+        linux_aarch64 = { "/usr/bin/lazygit", "/usr/local/bin/lazygit" },
+        macos_x86_64 = { "/usr/local/bin/lazygit" },
+        macos_arm64 = { "/opt/homebrew/bin/lazygit" },
+      }, { "lazygit" })
+    end,
+    {
+      description = "Lazygit terminal user interface for Git repositories.",
+      plugins = { "lazygit.nvim" },
+    }
+  )
+
+  define(
+    "ripgrep",
+    function()
+      return resolve("NVIM_PRO_KIT_RIPGREP", {
+        linux_x86_64 = { "/usr/bin/rg", "/usr/local/bin/rg" },
+        linux_aarch64 = { "/usr/bin/rg", "/usr/local/bin/rg" },
+        macos_x86_64 = { "/usr/local/bin/rg" },
+        macos_arm64 = { "/opt/homebrew/bin/rg" },
+      }, { "rg" })
+    end,
+    {
+      description = "ripgrep fast text searching utility used for project navigation.",
+      plugins = { "telescope.nvim" },
+    }
+  )
+
+  define(
+    "python",
+    function()
+      return resolve("NVIM_PRO_KIT_PYTHON", {
+        linux_x86_64 = { "/usr/bin/python3", "/usr/bin/python" },
+        linux_aarch64 = { "/usr/bin/python3", "/usr/bin/python" },
+        macos_x86_64 = { "/usr/local/bin/python3", "/usr/bin/python3" },
+        macos_arm64 = { "/opt/homebrew/bin/python3", "/usr/bin/python3" },
+      }, { "python3", "python" })
+    end,
+    {
+      description = "Python interpreter for debugging and tooling integration.",
+      plugins = { "nvim-dap-python" },
+    }
+  )
+
+  define(
+    "node",
+    function()
+      return resolve("NVIM_PRO_KIT_NODE", {
+        linux_x86_64 = { "/usr/bin/node", "/usr/local/bin/node" },
+        linux_aarch64 = { "/usr/bin/node", "/usr/local/bin/node" },
+        macos_x86_64 = { "/usr/local/bin/node" },
+        macos_arm64 = { "/opt/homebrew/bin/node" },
+      }, { "node" })
+    end,
+    {
+      description = "Node.js runtime for JavaScript and TypeScript tooling.",
+      plugins = {},
+    }
+  )
+
+  define(
+    "npm",
+    function()
+      return resolve("NVIM_PRO_KIT_NPM", {
+        linux_x86_64 = { "/usr/bin/npm", "/usr/local/bin/npm" },
+        linux_aarch64 = { "/usr/bin/npm", "/usr/local/bin/npm" },
+        macos_x86_64 = { "/usr/local/bin/npm" },
+        macos_arm64 = { "/opt/homebrew/bin/npm" },
+      }, { "npm" })
+    end,
+    {
+      description = "npm package manager for Node.js-based tooling.",
+      plugins = {},
+    }
+  )
+
+  define(
+    "tree_sitter",
+    function()
+      return resolve("NVIM_PRO_KIT_TREE_SITTER", {
+        linux_x86_64 = { "/usr/bin/tree-sitter", "/usr/local/bin/tree-sitter" },
+        linux_aarch64 = { "/usr/bin/tree-sitter", "/usr/local/bin/tree-sitter" },
+        macos_x86_64 = { "/usr/local/bin/tree-sitter" },
+        macos_arm64 = { "/opt/homebrew/bin/tree-sitter" },
+      }, { "tree-sitter" })
+    end,
+    {
+      description = "Tree-sitter CLI for working with parser grammars.",
+      plugins = {},
+    }
+  )
+
+  define(
+    "make",
+    function()
+      return resolve("NVIM_PRO_KIT_MAKE", {
+        linux_x86_64 = { "/usr/bin/make", "/usr/local/bin/make" },
+        linux_aarch64 = { "/usr/bin/make", "/usr/local/bin/make" },
+        macos_x86_64 = { "/usr/local/bin/gmake", "/usr/bin/make" },
+        macos_arm64 = { "/opt/homebrew/bin/gmake", "/usr/bin/make" },
+      }, { "gmake", "make" })
+    end,
+    {
+      description = "Make build tool required for compiling native dependencies.",
+      plugins = { "telescope-fzf-native.nvim", "LuaSnip" },
+    }
+  )
+
+  define(
+    "gdb",
+    function()
+      return resolve("NVIM_PRO_KIT_GDB", {
+        linux_x86_64 = { "/usr/bin/gdb", "/usr/local/bin/gdb" },
+        linux_aarch64 = { "/usr/bin/gdb", "/usr/local/bin/gdb" },
+        macos_x86_64 = { "/usr/local/bin/gdb" },
+        macos_arm64 = { "/opt/homebrew/bin/gdb" },
+      }, { "gdb" })
+    end,
+    {
+      description = "GNU Debugger integration for native debugging workflows.",
+      plugins = { "nvim-gdb" },
+    }
+  )
+
+  define(
+    "lua_ls",
+    function()
+      local mason = mason_tool("lua-language-server")
+      return resolve("NVIM_PRO_KIT_LUA_LS", {
+        linux_x86_64 = { "/usr/bin/lua-language-server", mason },
+        linux_aarch64 = { "/usr/bin/lua-language-server", mason },
+        macos_x86_64 = { "/usr/local/bin/lua-language-server", mason },
+        macos_arm64 = { "/opt/homebrew/bin/lua-language-server", mason },
+      }, { mason, "lua-language-server" })
+    end,
+    {
+      description = "Lua Language Server for Lua development.",
+      plugins = { "nvim-lspconfig" },
+    }
+  )
+
+  define(
+    "pyright",
+    function()
+      local mason = mason_tool("pyright-langserver")
+      return resolve("NVIM_PRO_KIT_PYRIGHT", {
+        linux_x86_64 = { "/usr/bin/pyright-langserver", "/usr/local/bin/pyright-langserver", mason },
+        linux_aarch64 = { "/usr/bin/pyright-langserver", "/usr/local/bin/pyright-langserver", mason },
+        macos_x86_64 = { "/usr/local/bin/pyright-langserver", mason },
+        macos_arm64 = { "/opt/homebrew/bin/pyright-langserver", mason },
+      }, { mason, "pyright-langserver" })
+    end,
+    {
+      description = "Pyright Language Server for Python projects.",
+      plugins = { "nvim-lspconfig" },
+    }
+  )
+
+  define(
+    "ts_ls",
+    function()
+      local mason = mason_tool("typescript-language-server")
+      return resolve("NVIM_PRO_KIT_TS_LS", {
+        linux_x86_64 = { "/usr/bin/typescript-language-server", "/usr/local/bin/typescript-language-server", mason },
+        linux_aarch64 = { "/usr/bin/typescript-language-server", "/usr/local/bin/typescript-language-server", mason },
+        macos_x86_64 = { "/usr/local/bin/typescript-language-server", mason },
+        macos_arm64 = { "/opt/homebrew/bin/typescript-language-server", mason },
+      }, { mason, "typescript-language-server" })
+    end,
+    {
+      description = "TypeScript Language Server for JavaScript and TypeScript.",
+      plugins = { "nvim-lspconfig" },
+    }
+  )
+
+  define(
+    "hg",
+    function()
+      return resolve("NVIM_PRO_KIT_HG", {
+        linux_x86_64 = { "/usr/bin/hg", "/usr/local/bin/hg" },
+        linux_aarch64 = { "/usr/bin/hg", "/usr/local/bin/hg" },
+        macos_x86_64 = { "/usr/local/bin/hg" },
+        macos_arm64 = { "/opt/homebrew/bin/hg" },
+      }, { "hg" })
+    end,
+    {
+      description = "Mercurial distributed version control client.",
+      plugins = { "diffview.nvim" },
+    }
+  )
+end

--- a/nvim/lua/config/tools/init.lua
+++ b/nvim/lua/config/tools/init.lua
@@ -132,137 +132,28 @@ end
 
 local cache = {}
 local resolvers = {}
+local documentation = {}
 
-local function define(name, resolver)
+local function define(name, resolver, doc)
   local function wrapped()
     if cache[name] == nil then
       cache[name] = resolver()
     end
     return cache[name]
   end
+
   M[name] = wrapped
   resolvers[name] = wrapped
+  if doc then
+    documentation[name] = doc
+  end
 end
 
-define("git", function()
-  return resolve("NVIM_PRO_KIT_GIT", {
-    linux_x86_64 = { "/usr/bin/git", "/usr/local/bin/git" },
-    linux_aarch64 = { "/usr/bin/git", "/usr/local/bin/git" },
-    macos_x86_64 = { "/usr/local/bin/git" },
-    macos_arm64 = { "/opt/homebrew/bin/git" },
-  }, { "git" })
-end)
-
-define("lazygit", function()
-  return resolve("NVIM_PRO_KIT_LAZYGIT", {
-    linux_x86_64 = { "/usr/bin/lazygit", "/usr/local/bin/lazygit" },
-    linux_aarch64 = { "/usr/bin/lazygit", "/usr/local/bin/lazygit" },
-    macos_x86_64 = { "/usr/local/bin/lazygit" },
-    macos_arm64 = { "/opt/homebrew/bin/lazygit" },
-  }, { "lazygit" })
-end)
-
-define("ripgrep", function()
-  return resolve("NVIM_PRO_KIT_RIPGREP", {
-    linux_x86_64 = { "/usr/bin/rg", "/usr/local/bin/rg" },
-    linux_aarch64 = { "/usr/bin/rg", "/usr/local/bin/rg" },
-    macos_x86_64 = { "/usr/local/bin/rg" },
-    macos_arm64 = { "/opt/homebrew/bin/rg" },
-  }, { "rg" })
-end)
-
-define("python", function()
-  return resolve("NVIM_PRO_KIT_PYTHON", {
-    linux_x86_64 = { "/usr/bin/python3", "/usr/bin/python" },
-    linux_aarch64 = { "/usr/bin/python3", "/usr/bin/python" },
-    macos_x86_64 = { "/usr/local/bin/python3", "/usr/bin/python3" },
-    macos_arm64 = { "/opt/homebrew/bin/python3", "/usr/bin/python3" },
-  }, { "python3", "python" })
-end)
-
-define("node", function()
-  return resolve("NVIM_PRO_KIT_NODE", {
-    linux_x86_64 = { "/usr/bin/node", "/usr/local/bin/node" },
-    linux_aarch64 = { "/usr/bin/node", "/usr/local/bin/node" },
-    macos_x86_64 = { "/usr/local/bin/node" },
-    macos_arm64 = { "/opt/homebrew/bin/node" },
-  }, { "node" })
-end)
-
-define("npm", function()
-  return resolve("NVIM_PRO_KIT_NPM", {
-    linux_x86_64 = { "/usr/bin/npm", "/usr/local/bin/npm" },
-    linux_aarch64 = { "/usr/bin/npm", "/usr/local/bin/npm" },
-    macos_x86_64 = { "/usr/local/bin/npm" },
-    macos_arm64 = { "/opt/homebrew/bin/npm" },
-  }, { "npm" })
-end)
-
-define("tree_sitter", function()
-  return resolve("NVIM_PRO_KIT_TREE_SITTER", {
-    linux_x86_64 = { "/usr/bin/tree-sitter", "/usr/local/bin/tree-sitter" },
-    linux_aarch64 = { "/usr/bin/tree-sitter", "/usr/local/bin/tree-sitter" },
-    macos_x86_64 = { "/usr/local/bin/tree-sitter" },
-    macos_arm64 = { "/opt/homebrew/bin/tree-sitter" },
-  }, { "tree-sitter" })
-end)
-
-define("make", function()
-  return resolve("NVIM_PRO_KIT_MAKE", {
-    linux_x86_64 = { "/usr/bin/make", "/usr/local/bin/make" },
-    linux_aarch64 = { "/usr/bin/make", "/usr/local/bin/make" },
-    macos_x86_64 = { "/usr/local/bin/gmake", "/usr/bin/make" },
-    macos_arm64 = { "/opt/homebrew/bin/gmake", "/usr/bin/make" },
-  }, { "gmake", "make" })
-end)
-
-define("gdb", function()
-  return resolve("NVIM_PRO_KIT_GDB", {
-    linux_x86_64 = { "/usr/bin/gdb", "/usr/local/bin/gdb" },
-    linux_aarch64 = { "/usr/bin/gdb", "/usr/local/bin/gdb" },
-    macos_x86_64 = { "/usr/local/bin/gdb" },
-    macos_arm64 = { "/opt/homebrew/bin/gdb" },
-  }, { "gdb" })
-end)
-
-define("lua_ls", function()
-  local mason = mason_tool("lua-language-server")
-  return resolve("NVIM_PRO_KIT_LUA_LS", {
-    linux_x86_64 = { "/usr/bin/lua-language-server", mason },
-    linux_aarch64 = { "/usr/bin/lua-language-server", mason },
-    macos_x86_64 = { "/usr/local/bin/lua-language-server", mason },
-    macos_arm64 = { "/opt/homebrew/bin/lua-language-server", mason },
-  }, { mason, "lua-language-server" })
-end)
-
-define("pyright", function()
-  local mason = mason_tool("pyright-langserver")
-  return resolve("NVIM_PRO_KIT_PYRIGHT", {
-    linux_x86_64 = { "/usr/bin/pyright-langserver", "/usr/local/bin/pyright-langserver", mason },
-    linux_aarch64 = { "/usr/bin/pyright-langserver", "/usr/local/bin/pyright-langserver", mason },
-    macos_x86_64 = { "/usr/local/bin/pyright-langserver", mason },
-    macos_arm64 = { "/opt/homebrew/bin/pyright-langserver", mason },
-  }, { mason, "pyright-langserver" })
-end)
-
-define("ts_ls", function()
-  local mason = mason_tool("typescript-language-server")
-  return resolve("NVIM_PRO_KIT_TS_LS", {
-    linux_x86_64 = { "/usr/bin/typescript-language-server", "/usr/local/bin/typescript-language-server", mason },
-    linux_aarch64 = { "/usr/bin/typescript-language-server", "/usr/local/bin/typescript-language-server", mason },
-    macos_x86_64 = { "/usr/local/bin/typescript-language-server", mason },
-    macos_arm64 = { "/opt/homebrew/bin/typescript-language-server", mason },
-  }, { mason, "typescript-language-server" })
-end)
-
-define("hg", function()
-  return resolve("NVIM_PRO_KIT_HG", {
-    linux_x86_64 = { "/usr/bin/hg", "/usr/local/bin/hg" },
-    linux_aarch64 = { "/usr/bin/hg", "/usr/local/bin/hg" },
-    macos_x86_64 = { "/usr/local/bin/hg" },
-    macos_arm64 = { "/opt/homebrew/bin/hg" },
-  }, { "hg" })
-end)
+require("config.tools.definitions")({
+  define = define,
+  resolve = resolve,
+  mason_tool = mason_tool,
+})
 
 local lsp_args = {
   lua_ls = {},
@@ -378,6 +269,14 @@ function M.setup()
   end
   M.compilers()
   return M
+end
+
+function M.doc(tool)
+  return documentation[tool]
+end
+
+function M.docs()
+  return vim.deepcopy(documentation)
 end
 
 return M


### PR DESCRIPTION
## Summary
- split the tool helpers into a support module and a dedicated definitions file
- add inline documentation for every tool describing its purpose and dependent plugins
- refresh the README to point at the new tool module layout

## Testing
- `nvim --headless +'lua require("config.tools").setup()' +qa` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d401b3b20c833197e41a19462e38d0