### PR TITLE
Add helper to list resolved tool paths

### DIFF
--- a/nvim/lua/config/tools/init.lua
+++ b/nvim/lua/config/tools/init.lua
@@ -177,6 +177,18 @@ function M.ensure_on_path(tool)
   return M.binary(tool)
 end
 
+function M.paths()
+  local names = vim.tbl_keys(resolvers)
+  table.sort(names)
+
+  local result = {}
+  for _, name in ipairs(names) do
+    result[name] = resolvers[name]()
+  end
+
+  return result
+end
+
 function M.lsp_cmd(server)
   local binary = M.binary(server)
   if not binary then


### PR DESCRIPTION
## Summary
- add a `paths()` helper to `config.tools` that returns the resolved binaries

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d404d2867c8331a62da189857fae97