### PR TITLE
Fix Tools command missing indicators

### DIFF
--- a/nvim/lua/config/tools/init.lua
+++ b/nvim/lua/config/tools/init.lua
@@ -186,8 +186,10 @@ function M.paths()
   local missing = {}
   for _, name in ipairs(names) do
     local path = resolvers[name]()
-    result[name] = path
-    if not path then
+    if path then
+      result[name] = path
+    else
+      result[name] = false
       table.insert(missing, name)
     end
   end


### PR DESCRIPTION
## Summary
- keep tool names with unresolved binaries in the paths listing so the :Tools command can show them as missing

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d408ce925083318e3963575e6ad7f9