### PR TITLE
Add clangd tool registration and LSP setup

### DIFF
--- a/nvim/lua/config/tools/definitions.lua
+++ b/nvim/lua/config/tools/definitions.lua
@@ -199,6 +199,23 @@ return function(api)
   )
 
   define(
+    "clangd",
+    function()
+      local mason = mason_tool("clangd")
+      return resolve("NVIM_PRO_KIT_CLANGD", {
+        linux_x86_64 = { "/usr/bin/clangd", "/usr/local/bin/clangd", mason },
+        linux_aarch64 = { "/usr/bin/clangd", "/usr/local/bin/clangd", mason },
+        macos_x86_64 = { "/usr/local/opt/llvm/bin/clangd", "/usr/local/bin/clangd", mason },
+        macos_arm64 = { "/opt/homebrew/opt/llvm/bin/clangd", "/opt/homebrew/bin/clangd", mason },
+      }, { mason, "clangd" })
+    end,
+    {
+      description = "Clangd language server providing C and C++ support.",
+      plugins = { "nvim-lspconfig" },
+    }
+  )
+
+  define(
     "hg",
     function()
       return resolve("NVIM_PRO_KIT_HG", {

--- a/nvim/lua/config/tools/init.lua
+++ b/nvim/lua/config/tools/init.lua
@@ -160,6 +160,12 @@ local lsp_args = {
   lua_ls = {},
   pyright = { "--stdio" },
   ts_ls = { "--stdio" },
+  clangd = {
+    "--background-index",
+    "--clang-tidy",
+    "--completion-style=detailed",
+    "--function-arg-placeholders",
+  },
 }
 
 function M.binary(tool)

--- a/nvim/lua/plugins/nvim-lspconfig.lua
+++ b/nvim/lua/plugins/nvim-lspconfig.lua
@@ -58,6 +58,14 @@ return {
       ts_ls = {
         cmd = tools.lsp_cmd("ts_ls"),
       },
+      clangd = {
+        cmd = tools.lsp_cmd("clangd"),
+        filetypes = { "c", "cpp", "objc", "objcpp", "cuda" },
+        init_options = {
+          clangdFileStatus = true,
+          semanticHighlighting = true,
+        },
+      },
     }
 
     for server, config in pairs(servers) do


### PR DESCRIPTION
## Summary
- register clangd in the shared tool resolver with platform-aware paths
- configure default clangd arguments used when launching the server
- enable the clangd language server alongside existing LSP integrations

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d40a0a05e88331995132a0f76abcab