### PR TITLE
Refactor Tree-sitter vendor archives

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,14 +196,16 @@ The script compiles each parser with your platform C compiler (respects `$CC`) a
 
 ### Vendoring parser sources
 
-Run `scripts/treesitter-vendor.py` whenever the manifest changes or you need to refresh the vendored Tree-sitter sources. The script asks Neovim (headlessly) for each parser’s `install_info`, clones the upstream repositories, copies the declared source files into `vendor/tree-sitter/<lang>/`, records metadata in `vendor/tree-sitter/metadata.json`, and stages the updated directory so it is ready to commit. It also vendors the Tree-sitter runtime headers required by the compiler.
+Run `scripts/treesitter-vendor.py` whenever the manifest changes or you need to refresh the vendored Tree-sitter sources. The script asks Neovim (headlessly) for each parser’s `install_info`, clones the upstream repositories, packs the declared source files into `vendor/tree-sitter/<lang>.tar.bz2`, records metadata in `vendor/tree-sitter/metadata.json`, and stages the updated archives so they are ready to commit. It also vendors the Tree-sitter runtime headers required by the compiler.
 
 `scripts/treesitter-vendor.py` always pins repositories to the revisions listed in `vendor/plugins/nvim-treesitter/lockfile.json` so that the vendored sources line up with the parser versions bundled with `nvim-treesitter`. Update that lockfile (by refreshing the vendored `nvim-treesitter` plugin) before re-running the script to ensure reproducible snapshots.
 
 The TypeScript grammar, for example, provides a makefile that bakes in extra linker flags. The vendor script honours that entry point automatically, and you can invoke it manually when debugging a build:
 
 ```
-cd vendor/tree-sitter/typescript/typescript
+tmpdir=$(mktemp -d)
+tar -xjf vendor/tree-sitter/typescript.tar.bz2 -C "$tmpdir"
+cd "$tmpdir"/typescript/typescript
 TS=true make libtree-sitter-typescript.so
 ```
 
@@ -221,7 +223,7 @@ Set `NVIM_BIN` (or pass `--nvim`) if you want to use a specific Neovim binary (f
 
 1. `scripts/treesitter-vendor.py`
    * Clones or updates each grammar.
-   * Copies the declared sources into `vendor/tree-sitter/`.
+   * Compresses the declared sources into `vendor/tree-sitter/*.tar.bz2` archives.
    * Regenerates `metadata.json`.
    * Runs `git add -A vendor/tree-sitter` so the new snapshot is staged.
 2. `scripts/treesitter-sync.py`


### PR DESCRIPTION
## Summary
- update the Tree-sitter sync script to extract vendored parsers from .tar.bz2 archives before compiling
- change the vendor script to package parser repositories as compressed archives, validate their contents, and clean up obsolete snapshots
- refresh the README instructions to describe working with archived parser sources

## Testing
- python3 -m compileall scripts/treesitter-sync.py scripts/treesitter-vendor.py

------
https://chatgpt.com/codex/tasks/task_e_68d41abc35a48331a318c52a8f8fa9fb