### PR TITLE
feat(netrw): show browser in floating window

### DIFF
--- a/nvim/lua/config/netrw.lua
+++ b/nvim/lua/config/netrw.lua
@@ -3,13 +3,33 @@ local fn = vim.fn
 
 local group = api.nvim_create_augroup("config_netrw", { clear = true })
 
+local function float_config(width_ratio, height_ratio)
+  local columns = vim.o.columns
+  local lines = vim.o.lines
+
+  local width = math.max(math.floor(columns * width_ratio), 20)
+  local height = math.max(math.floor(lines * height_ratio), 10)
+  local row = math.floor((lines - height) / 2)
+  local col = math.floor((columns - width) / 2)
+
+  return {
+    relative = "editor",
+    width = width,
+    height = height,
+    row = row,
+    col = col,
+    style = "minimal",
+    border = "rounded",
+  }
+end
+
 api.nvim_create_autocmd("FileType", {
   group = group,
   pattern = "netrw",
   callback = function(event)
     local buf = event.buf
 
-    if vim.b[buf].config_netrw_split_applied then
+    if vim.b[buf].config_netrw_popup_applied then
       return
     end
 
@@ -17,20 +37,50 @@ api.nvim_create_autocmd("FileType", {
       return
     end
 
+    local origin_win = api.nvim_get_current_win()
     local alt_buf = fn.bufnr("#")
-    if alt_buf <= 0 or alt_buf == buf then
-      return
-    end
 
-    vim.b[buf].config_netrw_split_applied = true
-
-    local alt_win = fn.bufwinid(alt_buf)
-    if alt_win ~= -1 and alt_win ~= 0 then
-      api.nvim_set_current_win(alt_win)
+    if alt_buf > 0 and alt_buf ~= buf then
+      local alt_win = fn.bufwinid(alt_buf)
+      if alt_win ~= -1 and alt_win ~= 0 then
+        api.nvim_set_current_win(alt_win)
+      else
+        vim.cmd(string.format("keepalt buffer %d", alt_buf))
+      end
     else
-      vim.cmd(string.format("keepalt buffer %d", alt_buf))
+      local scratch = api.nvim_create_buf(false, true)
+      api.nvim_buf_set_option(scratch, "bufhidden", "wipe")
+      api.nvim_win_set_buf(origin_win, scratch)
     end
 
-    vim.cmd(string.format("keepalt vert sbuffer %d", buf))
+    local target_win = api.nvim_get_current_win()
+    local target_winnr = fn.win_id2win(target_win)
+
+    if target_winnr > 0 then
+      vim.b[buf].config_netrw_target_winnr = target_winnr
+      vim.g.netrw_chgwin = target_winnr
+    end
+
+    local win = api.nvim_open_win(buf, true, float_config(0.8, 0.8))
+    vim.wo[win].number = false
+    vim.wo[win].relativenumber = false
+    vim.wo[win].signcolumn = "no"
+
+    vim.b[buf].config_netrw_popup_applied = true
+    vim.b[buf].config_netrw_popup_win = win
+
+    api.nvim_create_autocmd("BufLeave", {
+      buffer = buf,
+      once = true,
+      callback = function()
+        if vim.g.netrw_chgwin == target_winnr then
+          vim.g.netrw_chgwin = nil
+        end
+
+        if api.nvim_win_is_valid(win) then
+          pcall(api.nvim_win_close, win, true)
+        end
+      end,
+    })
   end,
 })


### PR DESCRIPTION
## Summary
- replace the custom netrw split logic with a floating window presentation
- restore the previously active buffer before opening netrw so file selections reuse that window
- ensure the floating netrw window closes cleanly after leaving the buffer and reset netrw_chgwin

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d42b175d208331bf33dc52a56ec5dc