### PR TITLE
Ensure netrw buffers are wiped after leaving

### DIFF
--- a/nvim/lua/config/netrw.lua
+++ b/nvim/lua/config/netrw.lua
@@ -75,6 +75,12 @@ api.nvim_create_autocmd("FileType", {
         if api.nvim_win_is_valid(win) then
           pcall(api.nvim_win_close, win, true)
         end
+
+        vim.schedule(function()
+          if api.nvim_buf_is_valid(buf) then
+            pcall(api.nvim_buf_delete, buf, { force = true })
+          end
+        end)
       end,
     })
   end,


### PR DESCRIPTION
## Summary
- close the floating netrw window and wipe its buffer when leaving
- schedule the buffer deletion to avoid errors if netrw is still referenced

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d42e703028833191800b436bfdac4b