### PR TITLE
Tune bufferline tab width

### DIFF
--- a/nvim/lua/plugins/bufferline.lua
+++ b/nvim/lua/plugins/bufferline.lua
@@ -35,6 +35,9 @@ local spec = {
         mode = "buffers",
         themable = true,
         diagnostics = "nvim_lsp",
+        max_name_length = 18,
+        max_prefix_length = 10,
+        tab_size = 14,
         diagnostics_indicator = function(_, _, diagnostics_dict)
           for _, severity in ipairs({ "error", "warning", "info", "hint" }) do
             local count = diagnostics_dict[severity]


### PR DESCRIPTION
## Summary
- reduce the bufferline tab size and prefix length so more buffers can fit on screen at once

## Testing
- not run (configuration change)


------
https://chatgpt.com/codex/tasks/task_e_68d4332dfaf8833193db5f0d98a7db8f