### PR TITLE
feat(dap): add gdb adapter for cpp

### DIFF
--- a/nvim/lua/plugins/nvim-dap.lua
+++ b/nvim/lua/plugins/nvim-dap.lua
@@ -6,6 +6,7 @@ return {
   event = "VeryLazy",
   config = function()
     local dap = require("dap")
+    local tools = require("config.tools")
 
     local sign = vim.fn.sign_define
     sign("DapBreakpoint", { text = "", texthl = "DiagnosticSignError", linehl = "", numhl = "" })
@@ -29,5 +30,70 @@ return {
     end, vim.tbl_extend("force", opts, { desc = "DAP Set conditional breakpoint" }))
     map("n", "<leader>dl", dap.run_last, vim.tbl_extend("force", opts, { desc = "DAP Run last" }))
     map("n", "<leader>dr", dap.repl.toggle, vim.tbl_extend("force", opts, { desc = "DAP Toggle REPL" }))
+
+    local gdb = tools.binary("gdb")
+    if gdb then
+      dap.adapters.cpp = {
+        type = "executable",
+        command = gdb,
+        args = { "--interpreter=dap" },
+        name = "gdb",
+      }
+
+      local function prompt_program()
+        return vim.fn.input("Path to executable: ", vim.fn.getcwd() .. "/", "file")
+      end
+
+      local function prompt_arguments()
+        local input = vim.fn.input("Program arguments: ")
+        if input == nil or input == "" then
+          return {}
+        end
+        return vim.split(input, "%s+", { trimempty = true })
+      end
+
+      local function clone_configurations(configs)
+        local result = {}
+        for _, cfg in ipairs(configs) do
+          table.insert(result, vim.deepcopy(cfg))
+        end
+        return result
+      end
+
+      local configurations = {
+        {
+          name = "Launch executable",
+          type = "cpp",
+          request = "launch",
+          program = prompt_program,
+          args = prompt_arguments,
+          cwd = "${workspaceFolder}",
+          stopAtEntry = false,
+          setupCommands = {
+            {
+              text = "-enable-pretty-printing",
+              description = "Enable GDB pretty printing",
+              ignoreFailures = true,
+            },
+          },
+        },
+        {
+          name = "Attach to process",
+          type = "cpp",
+          request = "attach",
+          pid = require("dap.utils").pick_process,
+          cwd = "${workspaceFolder}",
+        },
+      }
+
+      dap.configurations.cpp = configurations
+      dap.configurations.c = clone_configurations(configurations)
+      dap.configurations.rust = clone_configurations(configurations)
+    else
+      vim.notify(
+        "nvim-pro-kit: GDB not found on PATH. Set NVIM_PRO_KIT_GDB or install gdb to enable native debugging.",
+        vim.log.levels.WARN
+      )
+    end
   end,
 }


### PR DESCRIPTION
## Summary
- configure `nvim-dap` to detect the configured GDB binary and register a DAP adapter for native toolchains
- provide default launch and attach configurations for C, C++, and Rust targets and warn if GDB is unavailable

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d4a72baabc8331be6cb5687e8bd43c