### PR TITLE
feat(dap): split cpp configuration

### DIFF
--- a/nvim/lua/plugins/nvim-dap-cpp.lua
+++ b/nvim/lua/plugins/nvim-dap-cpp.lua
@@ -1,0 +1,78 @@
+local util = require("config.util")
+local tools = require("config.tools")
+
+return {
+  name = "nvim-dap-cpp",
+  dir = util.repo_root(),
+  virtual = true,
+  dependencies = { "nvim-dap" },
+  ft = { "c", "cpp", "rust" },
+  config = function()
+    local dap = require("dap")
+
+    local gdb = tools.binary("gdb")
+    if not gdb then
+      vim.notify(
+        "nvim-pro-kit: GDB not found on PATH. Set NVIM_PRO_KIT_GDB or install gdb to enable native debugging.",
+        vim.log.levels.WARN
+      )
+    end
+
+    dap.adapters.cpp = {
+      type = "executable",
+      command = gdb or "gdb",
+      args = { "--interpreter=dap" },
+      name = "gdb",
+    }
+
+    local function prompt_program()
+      return vim.fn.input("Path to executable: ", vim.fn.getcwd() .. "/", "file")
+    end
+
+    local function prompt_arguments()
+      local input = vim.fn.input("Program arguments: ")
+      if input == nil or input == "" then
+        return {}
+      end
+      return vim.split(input, "%s+", { trimempty = true })
+    end
+
+    local function clone_configurations(configs)
+      local result = {}
+      for _, cfg in ipairs(configs) do
+        table.insert(result, vim.deepcopy(cfg))
+      end
+      return result
+    end
+
+    local configurations = {
+      {
+        name = "Launch executable",
+        type = "cpp",
+        request = "launch",
+        program = prompt_program,
+        args = prompt_arguments,
+        cwd = "${workspaceFolder}",
+        stopAtEntry = false,
+        setupCommands = {
+          {
+            text = "-enable-pretty-printing",
+            description = "Enable GDB pretty printing",
+            ignoreFailures = true,
+          },
+        },
+      },
+      {
+        name = "Attach to process",
+        type = "cpp",
+        request = "attach",
+        pid = require("dap.utils").pick_process,
+        cwd = "${workspaceFolder}",
+      },
+    }
+
+    dap.configurations.cpp = configurations
+    dap.configurations.c = clone_configurations(configurations)
+    dap.configurations.rust = clone_configurations(configurations)
+  end,
+}

--- a/nvim/lua/plugins/nvim-dap.lua
+++ b/nvim/lua/plugins/nvim-dap.lua
@@ -6,7 +6,6 @@ return {
   event = "VeryLazy",
   config = function()
     local dap = require("dap")
-    local tools = require("config.tools")
 
     local sign = vim.fn.sign_define
     sign("DapBreakpoint", { text = "", texthl = "DiagnosticSignError", linehl = "", numhl = "" })
@@ -72,69 +71,5 @@ return {
     map("n", "<leader>dl", dap.run_last, vim.tbl_extend("force", opts, { desc = "DAP Run last" }))
     map("n", "<leader>dr", dap.repl.toggle, vim.tbl_extend("force", opts, { desc = "DAP Toggle REPL" }))
 
-    local gdb = tools.binary("gdb")
-    if not gdb then
-      vim.notify(
-        "nvim-pro-kit: GDB not found on PATH. Set NVIM_PRO_KIT_GDB or install gdb to enable native debugging.",
-        vim.log.levels.WARN
-      )
-    end
-
-    dap.adapters.cpp = {
-      type = "executable",
-      command = gdb or "gdb",
-      args = { "--interpreter=dap" },
-      name = "gdb",
-    }
-
-    local function prompt_program()
-      return vim.fn.input("Path to executable: ", vim.fn.getcwd() .. "/", "file")
-    end
-
-    local function prompt_arguments()
-      local input = vim.fn.input("Program arguments: ")
-      if input == nil or input == "" then
-        return {}
-      end
-      return vim.split(input, "%s+", { trimempty = true })
-    end
-
-    local function clone_configurations(configs)
-      local result = {}
-      for _, cfg in ipairs(configs) do
-        table.insert(result, vim.deepcopy(cfg))
-      end
-      return result
-    end
-
-    local configurations = {
-      {
-        name = "Launch executable",
-        type = "cpp",
-        request = "launch",
-        program = prompt_program,
-        args = prompt_arguments,
-        cwd = "${workspaceFolder}",
-        stopAtEntry = false,
-        setupCommands = {
-          {
-            text = "-enable-pretty-printing",
-            description = "Enable GDB pretty printing",
-            ignoreFailures = true,
-          },
-        },
-      },
-      {
-        name = "Attach to process",
-        type = "cpp",
-        request = "attach",
-        pid = require("dap.utils").pick_process,
-        cwd = "${workspaceFolder}",
-      },
-    }
-
-    dap.configurations.cpp = configurations
-    dap.configurations.c = clone_configurations(configurations)
-    dap.configurations.rust = clone_configurations(configurations)
   end,
 }


### PR DESCRIPTION
## Summary
- keep the core nvim-dap plugin config focused on UI and keymaps
- move the C/C++/Rust adapter setup into a dedicated virtual plugin file that lazy-loads on relevant filetypes
- preserve the previous GDB prompts and launch/attach configurations in the new module

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d5312914f08331aab1418efd319879