### PR TITLE
Fix gdb adapter registration for nvim-dap

### DIFF
--- a/nvim/lua/plugins/nvim-dap-cpp.lua
+++ b/nvim/lua/plugins/nvim-dap-cpp.lua
@@ -19,13 +19,16 @@ return {
       )
     end
 
-    -- 1) 适配器：直接用 gdb 的 DAP 接口
-    dap.adapters.cpp = {
-      type = 'executable',
-      command = 'gdb',
-      args = { '--quiet', '--interpreter=dap' }, -- 关键：启用 DAP
-      name = 'gdb'
+    -- 1) Adapter: wire up the built-in GDB DAP interface
+    local adapter = {
+      type = "executable",
+      command = gdb or "gdb",
+      args = { "--quiet", "--interpreter=dap" },
+      name = "gdb",
     }
+
+    dap.adapters.gdb = adapter
+    dap.adapters.cpp = adapter
 
     -- 2) 针对 C/C++/Rust 的配置
     local function pick_exe()
@@ -35,17 +38,17 @@ return {
     dap.configurations.c = {
       {
         name = '(gdb) Launch',
-        type = 'gdb',
-        request = 'launch',
-        program = pick_exe,          -- 运行时选择 ./a.out 等
-        cwd = '${workspaceFolder}',
+        type = "gdb",
+        request = "launch",
+        program = pick_exe,
+        cwd = "${workspaceFolder}",
         stopOnEntry = false,
-        args = {},                   -- 需要参数时填 { "--flag", "value" }
+        args = {},
       },
       {
         name = '(gdb) Attach to process',
-        type = 'gdb',
-        request = 'attach',
+        type = "gdb",
+        request = "attach",
         processId = require('dap.utils').pick_process,
       },
     }


### PR DESCRIPTION
## Summary
- register the gdb adapter under the expected name so cpp/rust configurations activate
- reuse the resolved gdb binary and expose it through both `gdb` and `cpp` adapter aliases

## Testing
- `nvim --headless -u nvim/init.lua /tmp/sample.cpp +"lua assert(require('dap').adapters.gdb, 'gdb adapter missing')" +qa` *(fails: `nvim` binary not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d5361764748331bd0f6068fc6b6441