### PR TITLE
Load gdb adapter eagerly

### DIFF
--- a/nvim/lua/plugins/nvim-dap-cpp.lua
+++ b/nvim/lua/plugins/nvim-dap-cpp.lua
@@ -6,7 +6,7 @@ return {
   dir = util.repo_root(),
   virtual = true,
   dependencies = { "nvim-dap" },
-  ft = { "c", "cpp", "rust" },
+  event = "VeryLazy",
 
   config = function()
     local dap = require("dap")


### PR DESCRIPTION
## Summary
- load the nvim-dap gdb adapter on the VeryLazy event instead of waiting for language-specific buffers

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d53858cdbc8331b3ba31e22b8acf00