### PR TITLE
feat: add gdb launch command for nvim-dap

### DIFF
--- a/nvim/lua/plugins/nvim-dap-cpp.lua
+++ b/nvim/lua/plugins/nvim-dap-cpp.lua
@@ -6,10 +6,12 @@ return {
   dir = util.repo_root(),
   virtual = true,
   dependencies = { "nvim-dap" },
+  cmd = { "Dap_gdb" },
   event = "VeryLazy",
 
   config = function()
     local dap = require("dap")
+    local uv = vim.uv or vim.loop
 
     local gdb = tools.binary("gdb")
     if not gdb then
@@ -17,6 +19,37 @@ return {
         "nvim-pro-kit: GDB not found on PATH. Set NVIM_PRO_KIT_GDB or install gdb to enable native debugging.",
         vim.log.levels.WARN
       )
+    end
+
+    local function notify(message, level)
+      level = level or vim.log.levels.ERROR
+      if vim.notify then
+        vim.notify(message, level, { title = "nvim-pro-kit" })
+        return
+      end
+
+      vim.api.nvim_echo({ { message, "" } }, false, {})
+    end
+
+    local function resolve_launch_config(program)
+      local candidates = dap.configurations.cpp or dap.configurations.c or {}
+      local template = candidates[1]
+
+      if template then
+        local configuration = vim.deepcopy(template)
+        configuration.program = program
+        return configuration
+      end
+
+      return {
+        name = "(gdb) Launch",
+        type = "gdb",
+        request = "launch",
+        program = program,
+        cwd = vim.fn.getcwd(),
+        stopOnEntry = false,
+        args = {},
+      }
     end
 
     -- 1) Adapter: wire up the built-in GDB DAP interface
@@ -55,5 +88,36 @@ return {
 
     dap.configurations.cpp  = dap.configurations.c
     dap.configurations.rust = dap.configurations.c
+
+    pcall(vim.api.nvim_create_user_command, "Dap_gdb", function(opts)
+      if not gdb then
+        notify("nvim-pro-kit: GDB is not available (set NVIM_PRO_KIT_GDB or install gdb).")
+        return
+      end
+
+      local expanded = vim.fn.expand(opts.args)
+      if expanded == "" then
+        notify("nvim-pro-kit: Provide a path to an executable, e.g. :dap_gdb ./a.out")
+        return
+      end
+
+      local program = vim.fn.fnamemodify(expanded, ":p")
+      local stat = uv.fs_stat(program)
+      if not stat or stat.type ~= "file" then
+        notify(string.format("nvim-pro-kit: '%s' is not a valid executable file.", program))
+        return
+      end
+
+      if vim.fn.executable(program) ~= 1 then
+        notify(string.format("nvim-pro-kit: '%s' is not marked as executable.", program))
+        return
+      end
+
+      dap.run(resolve_launch_config(program))
+    end, {
+      nargs = 1,
+      complete = "file",
+      desc = "Debug an executable with GDB via nvim-dap",
+    })
   end,
 }


### PR DESCRIPTION
## Summary
- add a lazy command trigger for the cpp/gdb DAP integration
- expose :dap_gdb to validate executables and start a gdb debug session via nvim-dap

## Testing
- no tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d53ae271488331b09f3e7a8d847b5d