### PR TITLE
Fix nvim-dap-cpp command registration

### DIFF
--- a/nvim/lua/plugins/nvim-dap-cpp.lua
+++ b/nvim/lua/plugins/nvim-dap-cpp.lua
@@ -6,7 +6,7 @@ return {
   dir = util.repo_root(),
   virtual = true,
   dependencies = { "nvim-dap" },
-  cmd = { "Dap_gdb" },
+  cmd = { "DapGdb" },
   event = "VeryLazy",
 
   config = function()
@@ -89,7 +89,7 @@ return {
     dap.configurations.cpp  = dap.configurations.c
     dap.configurations.rust = dap.configurations.c
 
-    pcall(vim.api.nvim_create_user_command, "Dap_gdb", function(opts)
+    pcall(vim.api.nvim_create_user_command, "DapGdb", function(opts)
       if not gdb then
         notify("nvim-pro-kit: GDB is not available (set NVIM_PRO_KIT_GDB or install gdb).")
         return
@@ -97,7 +97,7 @@ return {
 
       local expanded = vim.fn.expand(opts.args)
       if expanded == "" then
-        notify("nvim-pro-kit: Provide a path to an executable, e.g. :dap_gdb ./a.out")
+        notify("nvim-pro-kit: Provide a path to an executable, e.g. :DapGdb ./a.out")
         return
       end
 


### PR DESCRIPTION
## Summary
- rename the virtual command registered for nvim-dap-cpp to use a valid name
- update user-facing messaging to match the corrected :DapGdb command

## Testing
- `nvim --headless "+quit"` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d53fbb5d7c8331835983b975a8e703