### PR TITLE
feat: stop GDB sessions at entry

### DIFF
--- a/nvim/lua/plugins/nvim-dap-cpp.lua
+++ b/nvim/lua/plugins/nvim-dap-cpp.lua
@@ -47,7 +47,7 @@ return {
         request = "launch",
         program = program,
         cwd = vim.fn.getcwd(),
-        stopOnEntry = false,
+        stopOnEntry = true,
         args = {},
       }
     end
@@ -75,7 +75,7 @@ return {
         request = "launch",
         program = pick_exe,
         cwd = "${workspaceFolder}",
-        stopOnEntry = false,
+        stopOnEntry = true,
         args = {},
       },
       {


### PR DESCRIPTION
## Summary
- configure the default GDB launch configuration used by :DapGdb to stop on entry
- ensure the generated launch configuration also pauses immediately so the DAP UI remains open

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d541965a788331b3e573122ce00fa0