### PR TITLE
refactor: simplify gdb dap setup

### DIFF
--- a/nvim/lua/plugins/nvim-dap-cpp.lua
+++ b/nvim/lua/plugins/nvim-dap-cpp.lua
@@ -11,111 +11,64 @@ return {
 
   config = function()
     local dap = require("dap")
-    local uv = vim.uv or vim.loop
 
-    local gdb = tools.binary("gdb")
-    if not gdb then
-      vim.notify(
-        "nvim-pro-kit: GDB not found on PATH. Set NVIM_PRO_KIT_GDB or install gdb to enable native debugging.",
-        vim.log.levels.WARN
-      )
+    local gdb = tools.binary("gdb") or "gdb"
+
+    dap.adapters.gdb = {
+      type = "executable",
+      command = gdb,
+      args = { "-i", "dap" },
+    }
+
+    dap.adapters.cpp = dap.adapters.gdb
+
+    local function pick_executable()
+      return vim.fn.input("Path to executable: ", vim.fn.getcwd() .. "/", "file")
     end
 
-    local function notify(message, level)
-      level = level or vim.log.levels.ERROR
-      if vim.notify then
-        vim.notify(message, level, { title = "nvim-pro-kit" })
-        return
-      end
-
-      vim.api.nvim_echo({ { message, "" } }, false, {})
-    end
-
-    local function resolve_launch_config(program)
-      local candidates = dap.configurations.cpp or dap.configurations.c or {}
-      local template = candidates[1]
-
-      if template then
-        local configuration = vim.deepcopy(template)
-        configuration.program = program
-        return configuration
-      end
-
+    local function base_launch_config()
       return {
         name = "(gdb) Launch",
         type = "gdb",
         request = "launch",
-        program = program,
-        cwd = vim.fn.getcwd(),
-        stopOnEntry = false,
+        cwd = "${workspaceFolder}",
+        stopOnEntry = true,
+        stopAtEntry = true,
         args = {},
       }
     end
 
-    -- 1) Adapter: wire up the built-in GDB DAP interface
-    local adapter = {
-      type = "executable",
-      command = gdb or "gdb",
-      args = { "--quiet", "--interpreter=dap" },
-      name = "gdb",
-    }
-
-    dap.adapters.gdb = adapter
-    dap.adapters.cpp = adapter
-
-    -- 2) 针对 C/C++/Rust 的配置
-    local function pick_exe()
-      return vim.fn.input('Path to executable: ', vim.fn.getcwd() .. '/', 'file')
-    end
-
     dap.configurations.c = {
+      vim.tbl_extend("force", base_launch_config(), { program = pick_executable }),
       {
-        name = '(gdb) Launch',
-        type = "gdb",
-        request = "launch",
-        program = pick_exe,
-        cwd = "${workspaceFolder}",
-        stopOnEntry = false,
-        args = {},
-      },
-      {
-        name = '(gdb) Attach to process',
+        name = "(gdb) Attach to process",
         type = "gdb",
         request = "attach",
-        processId = require('dap.utils').pick_process,
+        processId = require("dap.utils").pick_process,
       },
     }
 
-    dap.configurations.cpp  = dap.configurations.c
+    dap.configurations.cpp = dap.configurations.c
     dap.configurations.rust = dap.configurations.c
 
     pcall(vim.api.nvim_create_user_command, "DapGdb", function(opts)
-      if not gdb then
-        notify("nvim-pro-kit: GDB is not available (set NVIM_PRO_KIT_GDB or install gdb).")
+      local program = opts.args
+      if program == "" then
+        program = pick_executable()
+      else
+        program = vim.fn.fnamemodify(vim.fn.expand(program), ":p")
+      end
+
+      if not program or program == "" then
         return
       end
 
-      local expanded = vim.fn.expand(opts.args)
-      if expanded == "" then
-        notify("nvim-pro-kit: Provide a path to an executable, e.g. :DapGdb ./a.out")
-        return
-      end
-
-      local program = vim.fn.fnamemodify(expanded, ":p")
-      local stat = uv.fs_stat(program)
-      if not stat or stat.type ~= "file" then
-        notify(string.format("nvim-pro-kit: '%s' is not a valid executable file.", program))
-        return
-      end
-
-      if vim.fn.executable(program) ~= 1 then
-        notify(string.format("nvim-pro-kit: '%s' is not marked as executable.", program))
-        return
-      end
-
-      dap.run(resolve_launch_config(program))
+      local launch = base_launch_config()
+      launch.program = program
+      launch.cwd = vim.fn.getcwd()
+      dap.run(launch)
     end, {
-      nargs = 1,
+      nargs = "?",
       complete = "file",
       desc = "Debug an executable with GDB via nvim-dap",
     })


### PR DESCRIPTION
## Summary
- replace the custom gdb detection and launch helpers with the standard minimal nvim-dap configuration
- ensure generated launch configs set both stopOnEntry and stopAtEntry so hello-world programs pause instead of exiting immediately
- keep :DapGdb available while delegating most interaction to the default dap configuration tables

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d541965a788331b3e573122ce00fa0