### PR TITLE
Prevent gdb helper from auto-running inferior

### DIFF
--- a/nvim/lua/plugins/nvim-dap-cpp.lua
+++ b/nvim/lua/plugins/nvim-dap-cpp.lua
@@ -34,6 +34,7 @@ return {
         cwd = "${workspaceFolder}",
         stopOnEntry = true,
         stopAtEntry = true,
+        launchCompleteCommand = "None",
 
         args = {},
       }


### PR DESCRIPTION
## Summary
- configure the gdb DAP launch template to use launchCompleteCommand = "None"
- ensure :DapGdb loads the executable without immediately running it

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d547e617e8833183a03e78b880d4af