### PR TITLE
Allow DapGdb to load without running

### DIFF
--- a/nvim/lua/plugins/nvim-dap-cpp.lua
+++ b/nvim/lua/plugins/nvim-dap-cpp.lua
@@ -34,6 +34,7 @@ return {
         cwd = "${workspaceFolder}",
         stopOnEntry = true,
         stopAtEntry = true,
+        launchCompleteCommand = "None",
 
         args = {},
       }
@@ -66,6 +67,7 @@ return {
       if program == "" then
         program = pick_executable()
       else
+        -- Normalize any relative path or shell expansion to an absolute filename
         program = vim.fn.fnamemodify(vim.fn.expand(program), ":p")
       end
 
@@ -76,9 +78,18 @@ return {
       local launch = base_launch_config()
       launch.program = program
       launch.cwd = vim.fn.getcwd()
+      if opts.bang then
+        launch.launchCompleteCommand = "exec-run"
+      else
+        launch.launchCompleteCommand = "None"
+        launch.stopOnEntry = nil
+        launch.stopAtEntry = nil
+        vim.notify("Loaded program into GDB; use :DapContinue to run it", vim.log.levels.INFO)
+      end
       dap.run(launch)
     end, {
       nargs = "?",
+      bang = true,
       complete = "file",
       desc = "Debug an executable with GDB via nvim-dap",
     })


### PR DESCRIPTION
## Summary
- keep `:DapGdb` from immediately running the target by clearing the stop flags unless the command is invoked with a bang
- add a notification so users know to call `:DapContinue` after the helper just loads the binary

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d547e617e8833183a03e78b880d4af