### PR TITLE
Add DapGdb command for launching gdb sessions with arguments

### DIFF
--- a/nvim/lua/plugins/nvim-dap-cpp.lua
+++ b/nvim/lua/plugins/nvim-dap-cpp.lua
@@ -14,9 +14,9 @@ return {
 
     dap.adapters.gdb = {
       type = "executable",
-      command = "gdb",
-      args = { "-i", "dap"},
-    } 
+      command = gdb,
+      args = { "-i", "dap" },
+    }
 
     dap.configurations.cpp = {
       {
@@ -57,6 +57,27 @@ return {
 
     dap.configurations.c = dap.configurations.cpp
     dap.configurations.rust = dap.configurations.cpp
+
+    vim.api.nvim_create_user_command("DapGdb", function(command_opts)
+      local provided = command_opts.fargs
+      if #provided == 0 then
+        vim.notify("DapGdb requires an executable path", vim.log.levels.ERROR)
+        return
+      end
+
+      local args = vim.deepcopy(provided)
+      local executable = table.remove(args, 1)
+
+      dap.run({
+        name = string.format("GDB: %s", executable),
+        type = "gdb",
+        request = "launch",
+        program = vim.fn.fnamemodify(executable, ":p"),
+        args = args,
+        cwd = vim.fn.getcwd(),
+        stopAtBeginningOfMainSubprogram = true,
+      })
+    end, { nargs = "+", complete = "file" })
 
     end,
 }


### PR DESCRIPTION
## Summary
- allow configuring the gdb adapter to use the detected gdb binary
- add a :DapGdb user command that launches gdb with a provided executable and arguments

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d55d7559208331963baad471e9528c