### PR TITLE
feat: add winbar titles for dap ui windows

### DIFF
--- a/nvim/lua/plugins/nvim-dap-ui.lua
+++ b/nvim/lua/plugins/nvim-dap-ui.lua
@@ -15,6 +15,43 @@ return {
 
     dapui.setup({})
 
+    if vim.fn.exists("+winbar") == 1 then
+      local controls = require("dapui.controls")
+      local original_controls = controls.controls
+      controls.controls = function(is_active)
+        local bar = original_controls(is_active)
+        local title = "DAP: REPL"
+        if not bar:find(title, 1, true) then
+          bar = bar .. " | " .. title .. " "
+        end
+        return bar
+      end
+      controls.refresh_control_panel()
+
+      local titles = {
+        dapui_scopes = "DAP: Scopes",
+        dapui_breakpoints = "DAP: Breakpoints",
+        dapui_stacks = "DAP: Stacks",
+        dapui_watches = "DAP: Watches",
+        dapui_repl = "DAP: REPL",
+        dapui_console = "DAP: Console",
+      }
+
+      local winbar_group = vim.api.nvim_create_augroup("DapUIWinbar", { clear = true })
+
+      vim.api.nvim_create_autocmd("BufWinEnter", {
+        group = winbar_group,
+        callback = function(event)
+          local title = titles[vim.bo[event.buf].filetype]
+          if not title or vim.bo[event.buf].filetype == "dapui_repl" then
+            return
+          end
+
+          pcall(vim.api.nvim_win_set_option, vim.api.nvim_get_current_win(), "winbar", " " .. title .. " ")
+        end,
+      })
+    end
+
     dap.listeners.after.event_initialized["dapui_config"] = function()
       dapui.open({})
     end


### PR DESCRIPTION
## Summary
- add winbar-based titles for the scopes, breakpoints, stacks, watches, and console DAP UI panes
- append a textual label to the DAP UI REPL controls winbar when available

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d56082ca6c833199cdc4a53032a6dd