### PR TITLE
Map DAP REPL commands for stack navigation

### DIFF
--- a/nvim/lua/plugins/nvim-dap.lua
+++ b/nvim/lua/plugins/nvim-dap.lua
@@ -7,6 +7,15 @@ return {
   config = function()
     local dap = require("dap")
 
+    dap.repl.commands = vim.tbl_extend("force", dap.repl.commands or {}, {
+      up = function()
+        dap.up()
+      end,
+      down = function()
+        dap.down()
+      end,
+    })
+
     local sign = vim.fn.sign_define
     sign("DapBreakpoint", { text = "", texthl = "DiagnosticSignError", linehl = "", numhl = "" })
     sign("DapBreakpointCondition", { text = "", texthl = "DiagnosticSignWarn", linehl = "", numhl = "" })


### PR DESCRIPTION
## Summary
- extend the DAP REPL command mappings so that `up` and `down` use the corresponding stack navigation helpers

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d565c6a5f8833183607daae3236c55