### PR TITLE
fix: show buffer ids in bufferline

### DIFF
--- a/nvim/lua/plugins/bufferline.lua
+++ b/nvim/lua/plugins/bufferline.lua
@@ -70,7 +70,7 @@ local spec = {
         indicator = {
           style = "underline",
         },
-        numbers = "ordinal",
+        numbers = "buffer_id",
       },
     })
 


### PR DESCRIPTION
## Summary
- use bufferline's buffer_id numbering so displayed tabs match Neovim buffer indices

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d4a2f01f58833195e4e43fcd29a528