### PR TITLE
Add minimal mini.nvim configuration

### DIFF
--- a/nvim/lua/plugins/mini.lua
+++ b/nvim/lua/plugins/mini.lua
@@ -1,0 +1,51 @@
+local util = require("config.util")
+
+return {
+  name = "mini.nvim",
+  dir = util.vendor("mini.nvim"),
+  event = "VeryLazy",
+  config = function()
+    require("mini.ai").setup()
+    require("mini.comment").setup()
+    require("mini.surround").setup()
+    require("mini.pairs").setup()
+
+    local clue = require("mini.clue")
+    clue.setup({
+      triggers = {
+        { mode = "n", keys = "<Leader>" },
+        { mode = "x", keys = "<Leader>" },
+        { mode = "n", keys = "g" },
+        { mode = "x", keys = "g" },
+        { mode = "n", keys = "z" },
+        { mode = "x", keys = "z" },
+        { mode = "n", keys = "[" },
+        { mode = "n", keys = "]" },
+        { mode = "n", keys = "'" },
+        { mode = "n", keys = "`" },
+        { mode = "x", keys = "'" },
+        { mode = "x", keys = "`" },
+        { mode = "n", keys = '"' },
+        { mode = "x", keys = '"' },
+        { mode = "i", keys = "<C-r>" },
+        { mode = "c", keys = "<C-r>" },
+        { mode = "n", keys = "<C-w>" },
+        { mode = "i", keys = "<C-x>" },
+      },
+      clues = {
+        clue.gen_clues.square_brackets(),
+        clue.gen_clues.builtin_completion(),
+        clue.gen_clues.g(),
+        clue.gen_clues.marks(),
+        clue.gen_clues.registers(),
+        clue.gen_clues.windows(),
+        clue.gen_clues.z(),
+        { mode = "n", keys = "<Leader>b", desc = "+Buffers" },
+        { mode = "n", keys = "<Leader>t", desc = "+Tabs" },
+      },
+      window = {
+        delay = 200,
+      },
+    })
+  end,
+}


### PR DESCRIPTION
## Summary
- add a lazy.nvim plugin specification for the vendored mini.nvim plugin
- enable the default setups for mini.ai, mini.comment, mini.surround, and mini.pairs
- configure mini.clue with common triggers and helpful leader key group hints

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d5f6230d748331867a44e39cbafa70