### PR TITLE
Add vim-fugitive support

### DIFF
--- a/nvim/lua/config/tools/definitions.lua
+++ b/nvim/lua/config/tools/definitions.lua
@@ -15,7 +15,7 @@ return function(api)
     end,
     {
       description = "Git distributed version control system.",
-      plugins = { "git-worktree.nvim", "gitsigns.nvim", "diffview.nvim" },
+      plugins = { "git-worktree.nvim", "gitsigns.nvim", "diffview.nvim", "vim-fugitive" },
     }
   )
 

--- a/nvim/lua/plugins/vim-fugitive.lua
+++ b/nvim/lua/plugins/vim-fugitive.lua
@@ -1,0 +1,23 @@
+local util = require("config.util")
+local tools = require("config.tools")
+
+return {
+  name = "vim-fugitive",
+  dir = util.vendor("vim-fugitive"),
+  cmd = { "Git", "G", "GBrowse", "Gdiffsplit", "Gvdiffsplit" },
+  keys = {
+    {
+      "<leader>gs",
+      function()
+        vim.cmd.Git()
+      end,
+      desc = "Open Fugitive Git status",
+    },
+  },
+  init = function()
+    local git_binary = tools.git()
+    if git_binary then
+      vim.g.fugitive_git_executable = git_binary
+    end
+  end,
+}

--- a/scripts/plugins-list.yaml
+++ b/scripts/plugins-list.yaml
@@ -48,6 +48,14 @@
     "ref": "main"
   },
   {
+    "category": "git",
+    "description": "Full-featured Git wrapper enabling Git commands inside Neovim.",
+    "depends": [],
+    "url": "https://github.com/tpope/vim-fugitive",
+    "name": "vim-fugitive",
+    "ref": "master"
+  },
+  {
     "category": "library",
     "description": "Utility Lua functions used by many Neovim plugins.",
     "depends": [],


### PR DESCRIPTION
## Summary
- add vim-fugitive to the vendored plugin manifest and register it with the shared tool resolver
- provide a lazy.nvim spec that wires vim-fugitive commands and a Git status keybinding

## Testing
- not run (Neovim binary is unavailable in the container)

------
https://chatgpt.com/codex/tasks/task_e_68d5fd136f3c8331ac3770d41520f539