### PR TITLE
Refine clangd resource limits

### DIFF
--- a/nvim/lua/config/tools/init.lua
+++ b/nvim/lua/config/tools/init.lua
@@ -162,9 +162,13 @@ local lsp_args = {
   ts_ls = { "--stdio" },
   clangd = {
     "--background-index",
+    "--background-index-priority=background",
     "--clang-tidy",
     "--completion-style=detailed",
     "--function-arg-placeholders",
+    "--limit-results=50",
+    "--malloc-trim",
+    "-j=1",
   },
 }
 


### PR DESCRIPTION
## Summary
- lower clangd's indexing priority to background to avoid competing with the UI
- limit completion result fan-out and enable malloc trimming to better conserve resources

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d60cb59f988331a339a1f6b3fb830e