### PR TITLE
Fix tmux clipboard fallback on older releases

### DIFF
--- a/nvim/lua/config/options.lua
+++ b/nvim/lua/config/options.lua
@@ -17,5 +17,40 @@ opt.timeoutlen = 400
 opt.updatetime = 250
 opt.completeopt = { "menu", "menuone", "noselect" }
 opt.clipboard = "unnamedplus"
+
+do
+  local function in_tmux()
+    local tmux_env = vim.env.TMUX
+    return type(tmux_env) == "string" and tmux_env ~= ""
+  end
+
+  local function tmux_binary_available()
+    return vim.fn.executable("tmux") == 1
+  end
+
+  -- Older tmux releases (for example the version bundled with CentOS 7) do not
+  -- passthrough OSC 52 sequences. When Neovim detects an unavailable clipboard
+  -- provider it falls back to OSC 52, which results in the escape sequence
+  -- becoming visible in the editor instead of copying the text. Detect this
+  -- scenario and prefer the tmux load-buffer / save-buffer workflow instead of
+  -- relying on OSC 52.
+  if vim.g.clipboard == nil and in_tmux() and tmux_binary_available() then
+    local copy = "tmux load-buffer -w -"
+    local paste = "tmux save-buffer -"
+
+    vim.g.clipboard = {
+      name = "tmux",
+      copy = {
+        ["+"] = copy,
+        ["*"] = copy,
+      },
+      paste = {
+        ["+"] = paste,
+        ["*"] = paste,
+      },
+      cache_enabled = false,
+    }
+  end
+end
 opt.wrap = false
 opt.mouse = "a"


### PR DESCRIPTION
## Summary
- ensure Neovim uses tmux load-buffer/save-buffer when running inside tmux so older releases do not echo OSC 52 sequences

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d6af04fb9883319d279947b8b1a703