### PR TITLE
Simplify bundled tool path resolution

### DIFF
--- a/nvim/lua/config/tools/definitions.lua
+++ b/nvim/lua/config/tools/definitions.lua
@@ -2,15 +2,37 @@ return function(api)
   local define = api.define
   local resolve = api.resolve
   local mason_tool = api.mason_tool
+  local repo_root = api.repo_root
+
+  local function repo_tool(path)
+    if not repo_root or repo_root == "" then
+      return nil
+    end
+    return repo_root .. "/" .. path
+  end
 
   define(
     "git",
     function()
       return resolve("NVIM_PRO_KIT_GIT", {
-        linux_x86_64 = { "/usr/bin/git", "/usr/local/bin/git" },
-        linux_aarch64 = { "/usr/bin/git", "/usr/local/bin/git" },
-        macos_x86_64 = { "/usr/local/bin/git" },
-        macos_arm64 = { "/opt/homebrew/bin/git" },
+        linux_x86_64 = {
+          repo_tool("tools/linux_x86_64/git/latest/git"),
+          "/usr/bin/git",
+          "/usr/local/bin/git",
+        },
+        linux_aarch64 = {
+          repo_tool("tools/linux_aarch64/git/latest/git"),
+          "/usr/bin/git",
+          "/usr/local/bin/git",
+        },
+        macos_x86_64 = {
+          repo_tool("tools/macos_x86_64/git/latest/git"),
+          "/usr/local/bin/git",
+        },
+        macos_arm64 = {
+          repo_tool("tools/macos_arm64/git/latest/git"),
+          "/opt/homebrew/bin/git",
+        },
       }, { "git" })
     end,
     {
@@ -23,10 +45,24 @@ return function(api)
     "lazygit",
     function()
       return resolve("NVIM_PRO_KIT_LAZYGIT", {
-        linux_x86_64 = { "/usr/bin/lazygit", "/usr/local/bin/lazygit" },
-        linux_aarch64 = { "/usr/bin/lazygit", "/usr/local/bin/lazygit" },
-        macos_x86_64 = { "/usr/local/bin/lazygit" },
-        macos_arm64 = { "/opt/homebrew/bin/lazygit" },
+        linux_x86_64 = {
+          repo_tool("tools/linux_x86_64/lazygit/latest/lazygit"),
+          "/usr/bin/lazygit",
+          "/usr/local/bin/lazygit",
+        },
+        linux_aarch64 = {
+          repo_tool("tools/linux_aarch64/lazygit/latest/lazygit"),
+          "/usr/bin/lazygit",
+          "/usr/local/bin/lazygit",
+        },
+        macos_x86_64 = {
+          repo_tool("tools/macos_x86_64/lazygit/latest/lazygit"),
+          "/usr/local/bin/lazygit",
+        },
+        macos_arm64 = {
+          repo_tool("tools/macos_arm64/lazygit/latest/lazygit"),
+          "/opt/homebrew/bin/lazygit",
+        },
       }, { "lazygit" })
     end,
     {
@@ -39,10 +75,24 @@ return function(api)
     "ripgrep",
     function()
       return resolve("NVIM_PRO_KIT_RIPGREP", {
-        linux_x86_64 = { "/usr/bin/rg", "/usr/local/bin/rg" },
-        linux_aarch64 = { "/usr/bin/rg", "/usr/local/bin/rg" },
-        macos_x86_64 = { "/usr/local/bin/rg" },
-        macos_arm64 = { "/opt/homebrew/bin/rg" },
+        linux_x86_64 = {
+          repo_tool("tools/linux_x86_64/ripgrep/latest/rg"),
+          "/usr/bin/rg",
+          "/usr/local/bin/rg",
+        },
+        linux_aarch64 = {
+          repo_tool("tools/linux_aarch64/ripgrep/latest/rg"),
+          "/usr/bin/rg",
+          "/usr/local/bin/rg",
+        },
+        macos_x86_64 = {
+          repo_tool("tools/macos_x86_64/ripgrep/latest/rg"),
+          "/usr/local/bin/rg",
+        },
+        macos_arm64 = {
+          repo_tool("tools/macos_arm64/ripgrep/latest/rg"),
+          "/opt/homebrew/bin/rg",
+        },
       }, { "rg" })
     end,
     {
@@ -55,10 +105,30 @@ return function(api)
     "python",
     function()
       return resolve("NVIM_PRO_KIT_PYTHON", {
-        linux_x86_64 = { "/usr/bin/python3", "/usr/bin/python" },
-        linux_aarch64 = { "/usr/bin/python3", "/usr/bin/python" },
-        macos_x86_64 = { "/usr/local/bin/python3", "/usr/bin/python3" },
-        macos_arm64 = { "/opt/homebrew/bin/python3", "/usr/bin/python3" },
+        linux_x86_64 = {
+          repo_tool("tools/linux_x86_64/python/latest/python3"),
+          repo_tool("tools/linux_x86_64/python3/latest/python3"),
+          "/usr/bin/python3",
+          "/usr/bin/python",
+        },
+        linux_aarch64 = {
+          repo_tool("tools/linux_aarch64/python/latest/python3"),
+          repo_tool("tools/linux_aarch64/python3/latest/python3"),
+          "/usr/bin/python3",
+          "/usr/bin/python",
+        },
+        macos_x86_64 = {
+          repo_tool("tools/macos_x86_64/python/latest/python3"),
+          repo_tool("tools/macos_x86_64/python3/latest/python3"),
+          "/usr/local/bin/python3",
+          "/usr/bin/python3",
+        },
+        macos_arm64 = {
+          repo_tool("tools/macos_arm64/python/latest/python3"),
+          repo_tool("tools/macos_arm64/python3/latest/python3"),
+          "/opt/homebrew/bin/python3",
+          "/usr/bin/python3",
+        },
       }, { "python3", "python" })
     end,
     {
@@ -71,10 +141,24 @@ return function(api)
     "node",
     function()
       return resolve("NVIM_PRO_KIT_NODE", {
-        linux_x86_64 = { "/usr/bin/node", "/usr/local/bin/node" },
-        linux_aarch64 = { "/usr/bin/node", "/usr/local/bin/node" },
-        macos_x86_64 = { "/usr/local/bin/node" },
-        macos_arm64 = { "/opt/homebrew/bin/node" },
+        linux_x86_64 = {
+          repo_tool("tools/linux_x86_64/node/latest/node"),
+          "/usr/bin/node",
+          "/usr/local/bin/node",
+        },
+        linux_aarch64 = {
+          repo_tool("tools/linux_aarch64/node/latest/node"),
+          "/usr/bin/node",
+          "/usr/local/bin/node",
+        },
+        macos_x86_64 = {
+          repo_tool("tools/macos_x86_64/node/latest/node"),
+          "/usr/local/bin/node",
+        },
+        macos_arm64 = {
+          repo_tool("tools/macos_arm64/node/latest/node"),
+          "/opt/homebrew/bin/node",
+        },
       }, { "node" })
     end,
     {
@@ -87,10 +171,24 @@ return function(api)
     "npm",
     function()
       return resolve("NVIM_PRO_KIT_NPM", {
-        linux_x86_64 = { "/usr/bin/npm", "/usr/local/bin/npm" },
-        linux_aarch64 = { "/usr/bin/npm", "/usr/local/bin/npm" },
-        macos_x86_64 = { "/usr/local/bin/npm" },
-        macos_arm64 = { "/opt/homebrew/bin/npm" },
+        linux_x86_64 = {
+          repo_tool("tools/linux_x86_64/npm/latest/npm"),
+          "/usr/bin/npm",
+          "/usr/local/bin/npm",
+        },
+        linux_aarch64 = {
+          repo_tool("tools/linux_aarch64/npm/latest/npm"),
+          "/usr/bin/npm",
+          "/usr/local/bin/npm",
+        },
+        macos_x86_64 = {
+          repo_tool("tools/macos_x86_64/npm/latest/npm"),
+          "/usr/local/bin/npm",
+        },
+        macos_arm64 = {
+          repo_tool("tools/macos_arm64/npm/latest/npm"),
+          "/opt/homebrew/bin/npm",
+        },
       }, { "npm" })
     end,
     {
@@ -103,10 +201,28 @@ return function(api)
     "tree_sitter",
     function()
       return resolve("NVIM_PRO_KIT_TREE_SITTER", {
-        linux_x86_64 = { "/usr/bin/tree-sitter", "/usr/local/bin/tree-sitter" },
-        linux_aarch64 = { "/usr/bin/tree-sitter", "/usr/local/bin/tree-sitter" },
-        macos_x86_64 = { "/usr/local/bin/tree-sitter" },
-        macos_arm64 = { "/opt/homebrew/bin/tree-sitter" },
+        linux_x86_64 = {
+          repo_tool("tools/linux_x86_64/tree-sitter/latest/tree-sitter"),
+          repo_tool("tools/linux_x86_64/tree_sitter/latest/tree-sitter"),
+          "/usr/bin/tree-sitter",
+          "/usr/local/bin/tree-sitter",
+        },
+        linux_aarch64 = {
+          repo_tool("tools/linux_aarch64/tree-sitter/latest/tree-sitter"),
+          repo_tool("tools/linux_aarch64/tree_sitter/latest/tree-sitter"),
+          "/usr/bin/tree-sitter",
+          "/usr/local/bin/tree-sitter",
+        },
+        macos_x86_64 = {
+          repo_tool("tools/macos_x86_64/tree-sitter/latest/tree-sitter"),
+          repo_tool("tools/macos_x86_64/tree_sitter/latest/tree-sitter"),
+          "/usr/local/bin/tree-sitter",
+        },
+        macos_arm64 = {
+          repo_tool("tools/macos_arm64/tree-sitter/latest/tree-sitter"),
+          repo_tool("tools/macos_arm64/tree_sitter/latest/tree-sitter"),
+          "/opt/homebrew/bin/tree-sitter",
+        },
       }, { "tree-sitter" })
     end,
     {
@@ -119,10 +235,28 @@ return function(api)
     "make",
     function()
       return resolve("NVIM_PRO_KIT_MAKE", {
-        linux_x86_64 = { "/usr/bin/make", "/usr/local/bin/make" },
-        linux_aarch64 = { "/usr/bin/make", "/usr/local/bin/make" },
-        macos_x86_64 = { "/usr/local/bin/gmake", "/usr/bin/make" },
-        macos_arm64 = { "/opt/homebrew/bin/gmake", "/usr/bin/make" },
+        linux_x86_64 = {
+          repo_tool("tools/linux_x86_64/make/latest/make"),
+          "/usr/bin/make",
+          "/usr/local/bin/make",
+        },
+        linux_aarch64 = {
+          repo_tool("tools/linux_aarch64/make/latest/make"),
+          "/usr/bin/make",
+          "/usr/local/bin/make",
+        },
+        macos_x86_64 = {
+          repo_tool("tools/macos_x86_64/make/latest/gmake"),
+          repo_tool("tools/macos_x86_64/make/latest/make"),
+          "/usr/local/bin/gmake",
+          "/usr/bin/make",
+        },
+        macos_arm64 = {
+          repo_tool("tools/macos_arm64/make/latest/gmake"),
+          repo_tool("tools/macos_arm64/make/latest/make"),
+          "/opt/homebrew/bin/gmake",
+          "/usr/bin/make",
+        },
       }, { "gmake", "make" })
     end,
     {
@@ -135,10 +269,24 @@ return function(api)
     "gdb",
     function()
       return resolve("NVIM_PRO_KIT_GDB", {
-        linux_x86_64 = { "/usr/bin/gdb", "/usr/local/bin/gdb" },
-        linux_aarch64 = { "/usr/bin/gdb", "/usr/local/bin/gdb" },
-        macos_x86_64 = { "/usr/local/bin/gdb" },
-        macos_arm64 = { "/opt/homebrew/bin/gdb" },
+        linux_x86_64 = {
+          repo_tool("tools/linux_x86_64/gdb/latest/gdb"),
+          "/usr/bin/gdb",
+          "/usr/local/bin/gdb",
+        },
+        linux_aarch64 = {
+          repo_tool("tools/linux_aarch64/gdb/latest/gdb"),
+          "/usr/bin/gdb",
+          "/usr/local/bin/gdb",
+        },
+        macos_x86_64 = {
+          repo_tool("tools/macos_x86_64/gdb/latest/gdb"),
+          "/usr/local/bin/gdb",
+        },
+        macos_arm64 = {
+          repo_tool("tools/macos_arm64/gdb/latest/gdb"),
+          "/opt/homebrew/bin/gdb",
+        },
       }, { "gdb" })
     end,
     {
@@ -152,10 +300,30 @@ return function(api)
     function()
       local mason = mason_tool("lua-language-server")
       return resolve("NVIM_PRO_KIT_LUA_LS", {
-        linux_x86_64 = { "/usr/bin/lua-language-server", mason },
-        linux_aarch64 = { "/usr/bin/lua-language-server", mason },
-        macos_x86_64 = { "/usr/local/bin/lua-language-server", mason },
-        macos_arm64 = { "/opt/homebrew/bin/lua-language-server", mason },
+        linux_x86_64 = {
+          repo_tool("tools/linux_x86_64/lua-language-server/latest/bin/lua-language-server"),
+          repo_tool("tools/linux_x86_64/lua-language-server/latest/lua-language-server"),
+          "/usr/bin/lua-language-server",
+          mason,
+        },
+        linux_aarch64 = {
+          repo_tool("tools/linux_aarch64/lua-language-server/latest/bin/lua-language-server"),
+          repo_tool("tools/linux_aarch64/lua-language-server/latest/lua-language-server"),
+          "/usr/bin/lua-language-server",
+          mason,
+        },
+        macos_x86_64 = {
+          repo_tool("tools/macos_x86_64/lua-language-server/latest/bin/lua-language-server"),
+          repo_tool("tools/macos_x86_64/lua-language-server/latest/lua-language-server"),
+          "/usr/local/bin/lua-language-server",
+          mason,
+        },
+        macos_arm64 = {
+          repo_tool("tools/macos_arm64/lua-language-server/latest/bin/lua-language-server"),
+          repo_tool("tools/macos_arm64/lua-language-server/latest/lua-language-server"),
+          "/opt/homebrew/bin/lua-language-server",
+          mason,
+        },
       }, { mason, "lua-language-server" })
     end,
     {
@@ -169,10 +337,32 @@ return function(api)
     function()
       local mason = mason_tool("pyright-langserver")
       return resolve("NVIM_PRO_KIT_PYRIGHT", {
-        linux_x86_64 = { "/usr/bin/pyright-langserver", "/usr/local/bin/pyright-langserver", mason },
-        linux_aarch64 = { "/usr/bin/pyright-langserver", "/usr/local/bin/pyright-langserver", mason },
-        macos_x86_64 = { "/usr/local/bin/pyright-langserver", mason },
-        macos_arm64 = { "/opt/homebrew/bin/pyright-langserver", mason },
+        linux_x86_64 = {
+          repo_tool("tools/linux_x86_64/pyright/latest/pyright-langserver"),
+          repo_tool("tools/linux_x86_64/pyright-langserver/latest/pyright-langserver"),
+          "/usr/bin/pyright-langserver",
+          "/usr/local/bin/pyright-langserver",
+          mason,
+        },
+        linux_aarch64 = {
+          repo_tool("tools/linux_aarch64/pyright/latest/pyright-langserver"),
+          repo_tool("tools/linux_aarch64/pyright-langserver/latest/pyright-langserver"),
+          "/usr/bin/pyright-langserver",
+          "/usr/local/bin/pyright-langserver",
+          mason,
+        },
+        macos_x86_64 = {
+          repo_tool("tools/macos_x86_64/pyright/latest/pyright-langserver"),
+          repo_tool("tools/macos_x86_64/pyright-langserver/latest/pyright-langserver"),
+          "/usr/local/bin/pyright-langserver",
+          mason,
+        },
+        macos_arm64 = {
+          repo_tool("tools/macos_arm64/pyright/latest/pyright-langserver"),
+          repo_tool("tools/macos_arm64/pyright-langserver/latest/pyright-langserver"),
+          "/opt/homebrew/bin/pyright-langserver",
+          mason,
+        },
       }, { mason, "pyright-langserver" })
     end,
     {
@@ -186,10 +376,32 @@ return function(api)
     function()
       local mason = mason_tool("typescript-language-server")
       return resolve("NVIM_PRO_KIT_TS_LS", {
-        linux_x86_64 = { "/usr/bin/typescript-language-server", "/usr/local/bin/typescript-language-server", mason },
-        linux_aarch64 = { "/usr/bin/typescript-language-server", "/usr/local/bin/typescript-language-server", mason },
-        macos_x86_64 = { "/usr/local/bin/typescript-language-server", mason },
-        macos_arm64 = { "/opt/homebrew/bin/typescript-language-server", mason },
+        linux_x86_64 = {
+          repo_tool("tools/linux_x86_64/typescript-language-server/latest/typescript-language-server"),
+          repo_tool("tools/linux_x86_64/tsserver/latest/typescript-language-server"),
+          "/usr/bin/typescript-language-server",
+          "/usr/local/bin/typescript-language-server",
+          mason,
+        },
+        linux_aarch64 = {
+          repo_tool("tools/linux_aarch64/typescript-language-server/latest/typescript-language-server"),
+          repo_tool("tools/linux_aarch64/tsserver/latest/typescript-language-server"),
+          "/usr/bin/typescript-language-server",
+          "/usr/local/bin/typescript-language-server",
+          mason,
+        },
+        macos_x86_64 = {
+          repo_tool("tools/macos_x86_64/typescript-language-server/latest/typescript-language-server"),
+          repo_tool("tools/macos_x86_64/tsserver/latest/typescript-language-server"),
+          "/usr/local/bin/typescript-language-server",
+          mason,
+        },
+        macos_arm64 = {
+          repo_tool("tools/macos_arm64/typescript-language-server/latest/typescript-language-server"),
+          repo_tool("tools/macos_arm64/tsserver/latest/typescript-language-server"),
+          "/opt/homebrew/bin/typescript-language-server",
+          mason,
+        },
       }, { mason, "typescript-language-server" })
     end,
     {
@@ -203,10 +415,30 @@ return function(api)
     function()
       local mason = mason_tool("clangd")
       return resolve("NVIM_PRO_KIT_CLANGD", {
-        linux_x86_64 = { "/usr/bin/clangd", "/usr/local/bin/clangd", mason },
-        linux_aarch64 = { "/usr/bin/clangd", "/usr/local/bin/clangd", mason },
-        macos_x86_64 = { "/usr/local/opt/llvm/bin/clangd", "/usr/local/bin/clangd", mason },
-        macos_arm64 = { "/opt/homebrew/opt/llvm/bin/clangd", "/opt/homebrew/bin/clangd", mason },
+        linux_x86_64 = {
+          repo_tool("tools/linux_x86_64/clangd/latest/clangd"),
+          "/usr/bin/clangd",
+          "/usr/local/bin/clangd",
+          mason,
+        },
+        linux_aarch64 = {
+          repo_tool("tools/linux_aarch64/clangd/latest/clangd"),
+          "/usr/bin/clangd",
+          "/usr/local/bin/clangd",
+          mason,
+        },
+        macos_x86_64 = {
+          repo_tool("tools/macos_x86_64/clangd/latest/clangd"),
+          "/usr/local/opt/llvm/bin/clangd",
+          "/usr/local/bin/clangd",
+          mason,
+        },
+        macos_arm64 = {
+          repo_tool("tools/macos_arm64/clangd/latest/clangd"),
+          "/opt/homebrew/opt/llvm/bin/clangd",
+          "/opt/homebrew/bin/clangd",
+          mason,
+        },
       }, { mason, "clangd" })
     end,
     {
@@ -219,10 +451,28 @@ return function(api)
     "hg",
     function()
       return resolve("NVIM_PRO_KIT_HG", {
-        linux_x86_64 = { "/usr/bin/hg", "/usr/local/bin/hg" },
-        linux_aarch64 = { "/usr/bin/hg", "/usr/local/bin/hg" },
-        macos_x86_64 = { "/usr/local/bin/hg" },
-        macos_arm64 = { "/opt/homebrew/bin/hg" },
+        linux_x86_64 = {
+          repo_tool("tools/linux_x86_64/hg/latest/hg"),
+          repo_tool("tools/linux_x86_64/mercurial/latest/hg"),
+          "/usr/bin/hg",
+          "/usr/local/bin/hg",
+        },
+        linux_aarch64 = {
+          repo_tool("tools/linux_aarch64/hg/latest/hg"),
+          repo_tool("tools/linux_aarch64/mercurial/latest/hg"),
+          "/usr/bin/hg",
+          "/usr/local/bin/hg",
+        },
+        macos_x86_64 = {
+          repo_tool("tools/macos_x86_64/hg/latest/hg"),
+          repo_tool("tools/macos_x86_64/mercurial/latest/hg"),
+          "/usr/local/bin/hg",
+        },
+        macos_arm64 = {
+          repo_tool("tools/macos_arm64/hg/latest/hg"),
+          repo_tool("tools/macos_arm64/mercurial/latest/hg"),
+          "/opt/homebrew/bin/hg",
+        },
       }, { "hg" })
     end,
     {

--- a/nvim/lua/config/tools/init.lua
+++ b/nvim/lua/config/tools/init.lua
@@ -2,8 +2,10 @@ local M = {}
 
 local api = vim.api
 local uv = vim.uv or vim.loop
+local util = require("config.util")
 local dir_separator = package.config:sub(1, 1)
 local path_separator = package.config:sub(3, 3)
+local repo_root = util.repo_root()
 
 local function detect_platform()
   local uname = (uv and uv.os_uname and uv.os_uname()) or {}
@@ -154,6 +156,7 @@ require("config.tools.definitions")({
   define = define,
   resolve = resolve,
   mason_tool = mason_tool,
+  repo_root = repo_root,
 })
 
 local lsp_args = {


### PR DESCRIPTION
## Summary
- pass the repo root into the tool definitions and build bundled paths without placeholder replacement
- drop the `<repo>` substitution step from the resolver so normalization works directly on full paths

## Testing
- `NVIM_APPNAME=nvim-pro-kit ./tools/linux_x86_64/nvim/latest/nvim --headless "+lua require('config.tools')" +q` *(fails: AppImage requires FUSE in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d750a035c08331a70ce9cfb01e2935