### PR TITLE
Add .tmux.conf layout preset key bindings

### DIFF
--- a/.tmux.conf
+++ b/.tmux.conf
@@ -1,0 +1,59 @@
+# -------------------------
+# Developer Layout Presets
+# -------------------------
+
+# 1 pane (focus mode)
+bind-key 1 run-shell "tmux kill-pane -a"
+
+# 2 panes (dev mode)
+bind-key 2 run-shell "
+  tmux kill-pane -a
+  tmux split-window -h
+  tmux select-layout even-horizontal
+"
+
+# 3 panes
+bind-key 3 run-shell "
+  tmux kill-pane -a
+  tmux split-window -h
+  tmux split-window -v
+  tmux select-layout tiled
+"
+
+# 4 panes
+bind-key 4 run-shell "
+  tmux kill-pane -a
+  tmux split-window -h
+  tmux split-window -v
+  tmux select-pane -t 0
+  tmux split-window -v
+  tmux select-layout tiled
+"
+
+# 6 panes
+bind-key 6 run-shell "
+  tmux kill-pane -a
+  i=1
+  while [ \"$i\" -le 5 ]; do
+    tmux split-window
+    i=$((i + 1))
+  done
+  tmux select-layout tiled
+"
+
+# 8 panes (monitor mode)
+bind-key 8 run-shell "
+  tmux kill-pane -a
+  i=1
+  while [ \"$i\" -le 7 ]; do
+    tmux split-window
+    i=$((i + 1))
+  done
+  tmux select-layout tiled
+"
+
+# 9: toggle zoom for current pane
+bind-key 9 resize-pane -Z
+
+# Grid auto-arrange helper
+bind-key g select-layout tiled


### PR DESCRIPTION
### Motivation

- Provide quick, repeatable workspace layouts for development and monitoring workflows via tmux key bindings.

### Description

- Add a repository-level ` .tmux.conf` that defines layout presets bound to `prefix + 1/2/3/4/6/8`, a zoom toggle on `prefix + 9`, and a grid auto-arrange helper on `prefix + g`.
- Implement pane creation for multi-pane presets using a POSIX-compatible `while` loop inside `run-shell` for better portability in `/bin/sh` contexts.
- Use `tmux select-layout` variants (`even-horizontal`, `tiled`) to normalize final pane arrangements.

### Testing

- Verified the bundled tmux binary with `./tools/linux_x86_64/tmux/3.5a/tmux -V`, which returned a valid version string.
- Loaded and sourced the new configuration using `./tools/linux_x86_64/tmux/3.5a/tmux -f .tmux.conf -L nvimprokit-test start-server \; source-file .tmux.conf \; kill-server`, which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b3b8b167688331bef969c691503ca4)